### PR TITLE
멤버 엔티티 클래스 작성

### DIFF
--- a/src/main/java/kr/codesquad/secondhand/domain/member/Member.java
+++ b/src/main/java/kr/codesquad/secondhand/domain/member/Member.java
@@ -1,0 +1,31 @@
+package kr.codesquad.secondhand.domain.member;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "member")
+@Entity
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 45, nullable = false)
+    private String email;
+
+    @Column(length = 512, nullable = false)
+    private String password;
+
+    @Column(length = 512, nullable = false)
+    private String profileUrl;
+}

--- a/src/main/java/kr/codesquad/secondhand/repository/member/MemberRepository.java
+++ b/src/main/java/kr/codesquad/secondhand/repository/member/MemberRepository.java
@@ -1,0 +1,7 @@
+package kr.codesquad.secondhand.repository.member;
+
+import kr.codesquad.secondhand.domain.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -5,6 +5,8 @@ spring:
     password: admin
 
   jpa:
+    hibernate:
+      ddl-auto: create-drop
     properties:
       hibernate:
         show_sql: true

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -24,7 +24,7 @@ CREATE TABLE IF NOT EXISTS `mydb`.`member`
     `email`       VARCHAR(45)  NOT NULL,
     `login_id`    VARCHAR(45)  NOT NULL,
     `password`    VARCHAR(512) NOT NULL,
-    `profile_url` VARCHAR(45)  NOT NULL,
+    `profile_url` VARCHAR(512) NOT NULL,
     PRIMARY KEY (`id`)
 ) ENGINE = InnoDB;
 


### PR DESCRIPTION
## Issues
- #3 

## What is this PR? 👓
초기 멤버 엔티티 클래스 작성에 대한 PR입니다.

## Key changes 🔑
- `Member` 엔티티 클래스 작성
- hibernate ddl-auto 옵션을 `create-drop`으로 설정

## To reviewers 👋
- 로컬 환경에서는 테스트하기 쉽도록 hibernate.ddl-auto 옵션을 `create-drop`으로 설정했습니다. 이후 배포 환경이나 개발 환경에서는 `validate` 옵션 사용을 고려합니다.
