### PR TITLE
리프레시 토큰 갱신 / 로그인 성공시 토큰 발급

### DIFF
--- a/src/main/java/kr/codesquad/secondhand/application/auth/MemberService.java
+++ b/src/main/java/kr/codesquad/secondhand/application/auth/MemberService.java
@@ -29,6 +29,7 @@ public class MemberService {
     private final NaverRequester naverRequester;
     private final JwtProvider jwtProvider;
 
+    @Transactional
     public LoginResponse login(LoginRequest request, String code) {
         OauthTokenResponse tokenResponse = naverRequester.getToken(code);
         UserProfile userProfile = naverRequester.getUserProfile(tokenResponse);

--- a/src/main/java/kr/codesquad/secondhand/application/auth/NaverRequester.java
+++ b/src/main/java/kr/codesquad/secondhand/application/auth/NaverRequester.java
@@ -1,4 +1,4 @@
-package kr.codesquad.secondhand.application;
+package kr.codesquad.secondhand.application.auth;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -64,11 +64,12 @@ public class NaverRequester {
         headers.setBearerAuth(tokenResponse.getAccessToken());
         HttpEntity<Void> request = new HttpEntity<>(headers);
 
-        ResponseEntity<Map<String, Object>> response =  restTemplate.exchange(
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
                 oauthProvider.getUserInfoUrl(),
                 HttpMethod.GET,
                 request,
-                new ParameterizedTypeReference<Map<String, Object>>() {}
+                new ParameterizedTypeReference<Map<String, Object>>() {
+                }
         );
         return response.getBody();
     }

--- a/src/main/java/kr/codesquad/secondhand/application/auth/TokenService.java
+++ b/src/main/java/kr/codesquad/secondhand/application/auth/TokenService.java
@@ -1,0 +1,32 @@
+package kr.codesquad.secondhand.application.auth;
+
+import kr.codesquad.secondhand.exception.ErrorCode;
+import kr.codesquad.secondhand.exception.UnAuthorizedException;
+import kr.codesquad.secondhand.infrastructure.jwt.JwtProvider;
+import kr.codesquad.secondhand.presentation.dto.token.AccessTokenResponse;
+import kr.codesquad.secondhand.repository.token.TokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class TokenService {
+
+    private final TokenRepository tokenRepository;
+    private final JwtProvider jwtProvider;
+
+    public AccessTokenResponse renewAccessToken(final String refreshToken) {
+        jwtProvider.validateToken(refreshToken);
+        Map<String, Object> claims = jwtProvider.extractClaims(refreshToken);
+        Long memberId = Long.valueOf(claims.get("memberId").toString());
+
+        if (!tokenRepository.existsById(memberId)) {
+            throw new UnAuthorizedException(ErrorCode.INVALID_TOKEN);
+        }
+        return new AccessTokenResponse(jwtProvider.createAccessToken(memberId));
+    }
+}

--- a/src/main/java/kr/codesquad/secondhand/domain/token/RefreshToken.java
+++ b/src/main/java/kr/codesquad/secondhand/domain/token/RefreshToken.java
@@ -1,0 +1,28 @@
+package kr.codesquad.secondhand.domain.token;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "refresh_token")
+@Entity
+public class RefreshToken {
+
+    @Id
+    private Long memberId;
+
+    @Column(length = 256, nullable = false)
+    private String token;
+
+    @Builder
+    private RefreshToken(Long memberId, String token) {
+        this.memberId = memberId;
+        this.token = token;
+    }
+}

--- a/src/main/java/kr/codesquad/secondhand/exception/DuplicatedException.java
+++ b/src/main/java/kr/codesquad/secondhand/exception/DuplicatedException.java
@@ -1,0 +1,8 @@
+package kr.codesquad.secondhand.exception;
+
+public class DuplicatedException extends SecondHandException {
+
+    public DuplicatedException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/kr/codesquad/secondhand/exception/ErrorCode.java
+++ b/src/main/java/kr/codesquad/secondhand/exception/ErrorCode.java
@@ -15,7 +15,11 @@ public enum ErrorCode {
     // IMAGE
     INVALID_IMAGE("유효하지 않은 이미지 입니다."),
     INVALID_FILE_EXTENSION("잘못된 파일 확장자 입니다."),
-    UPLOAD_FAIL("이미지 업로드 실패");
+    UPLOAD_FAIL("이미지 업로드 실패"),
+
+    // AUTH
+    INVALID_LOGIN_DATA("로그인 정보가 일치하지 않습니다."),
+    DUPLICATED_LOGIN_ID("중복된 아이디입니다.");
 
     private final String message;
 }

--- a/src/main/java/kr/codesquad/secondhand/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/codesquad/secondhand/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package kr.codesquad.secondhand.exception;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -11,6 +12,18 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleBadRequestException(BadRequestException e) {
         return ResponseEntity.badRequest()
                 .body(new ErrorResponse(400, e.getMessage()));
+    }
+
+    @ExceptionHandler(UnAuthorizedException.class)
+    public ResponseEntity<ErrorResponse> handleUnAuthorizedException(UnAuthorizedException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(new ErrorResponse(401, e.getMessage()));
+    }
+
+    @ExceptionHandler(DuplicatedException.class)
+    public ResponseEntity<ErrorResponse> handleDuplicatedException(DuplicatedException e) {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(new ErrorResponse(409, e.getMessage()));
     }
 
     @ExceptionHandler(InternalServerException.class)

--- a/src/main/java/kr/codesquad/secondhand/presentation/MemberController.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/MemberController.java
@@ -1,11 +1,14 @@
 package kr.codesquad.secondhand.presentation;
 
 import javax.validation.Valid;
-import kr.codesquad.secondhand.application.MemberService;
+import kr.codesquad.secondhand.application.auth.MemberService;
+import kr.codesquad.secondhand.application.auth.TokenService;
 import kr.codesquad.secondhand.presentation.dto.ApiResponse;
 import kr.codesquad.secondhand.presentation.dto.LoginRequest;
 import kr.codesquad.secondhand.presentation.dto.LoginResponse;
 import kr.codesquad.secondhand.presentation.dto.SignUpRequest;
+import kr.codesquad.secondhand.presentation.dto.token.AccessTokenResponse;
+import kr.codesquad.secondhand.presentation.dto.token.TokenRenewRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -21,23 +24,29 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
 
     private final MemberService memberService;
+    private final TokenService tokenService;
 
-    @PostMapping("/login")
+    @PostMapping("/login/naver")
     public ResponseEntity<ApiResponse<LoginResponse>> login(@RequestBody @Valid LoginRequest request,
                                                             @RequestParam String code, @RequestParam String state) {
-        return new ResponseEntity(
-                new ApiResponse<>(HttpStatus.OK.value(), memberService.login(request, code)),
-                HttpStatus.OK
-        );
+        return ResponseEntity.ok()
+                .body(new ApiResponse<>(HttpStatus.OK.value(), memberService.login(request, code)));
     }
 
-    @PostMapping("/signup")
-    public ResponseEntity<ApiResponse> signUp(@RequestBody @Valid SignUpRequest request,
-                                              @RequestParam String code, @RequestParam String state) {
+    @PostMapping("/signup/naver")
+    public ResponseEntity<ApiResponse<Void>> signUp(@RequestBody @Valid SignUpRequest request,
+                                                    @RequestParam String code, @RequestParam String state) {
         memberService.signUp(request, code);
-        return new ResponseEntity<>(
-                new ApiResponse(HttpStatus.CREATED.value()),
-                HttpStatus.CREATED
-        );
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new ApiResponse<>(HttpStatus.CREATED.value()));
+    }
+
+    @PostMapping("/token")
+    public ResponseEntity<ApiResponse<AccessTokenResponse>> renewAccessToken(@RequestBody TokenRenewRequest request) {
+        return ResponseEntity.ok()
+                .body(new ApiResponse<>(
+                        HttpStatus.OK.value(),
+                        tokenService.renewAccessToken(request.getRefreshToken())
+                ));
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/presentation/dto/LoginResponse.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/dto/LoginResponse.java
@@ -1,13 +1,16 @@
 package kr.codesquad.secondhand.presentation.dto;
 
+import kr.codesquad.secondhand.presentation.dto.token.AuthToken;
 import lombok.Getter;
 
 @Getter
 public class LoginResponse {
 
+    private final AuthToken jwt;
     private final UserResponse user;
 
-    public LoginResponse(UserResponse user) {
+    public LoginResponse(AuthToken authToken, UserResponse user) {
+        this.jwt = authToken;
         this.user = user;
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/presentation/dto/token/AccessTokenResponse.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/dto/token/AccessTokenResponse.java
@@ -1,0 +1,11 @@
+package kr.codesquad.secondhand.presentation.dto.token;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AccessTokenResponse {
+
+    private final String accessToken;
+}

--- a/src/main/java/kr/codesquad/secondhand/presentation/dto/token/AuthToken.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/dto/token/AuthToken.java
@@ -1,0 +1,12 @@
+package kr.codesquad.secondhand.presentation.dto.token;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AuthToken {
+
+    private final String accessToken;
+    private final String refreshToken;
+}

--- a/src/main/java/kr/codesquad/secondhand/presentation/dto/token/TokenRenewRequest.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/dto/token/TokenRenewRequest.java
@@ -1,0 +1,14 @@
+package kr.codesquad.secondhand.presentation.dto.token;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenRenewRequest {
+
+    private String refreshToken;
+}
+

--- a/src/main/java/kr/codesquad/secondhand/repository/token/TokenRepository.java
+++ b/src/main/java/kr/codesquad/secondhand/repository/token/TokenRepository.java
@@ -1,0 +1,7 @@
+package kr.codesquad.secondhand.repository.token;
+
+import kr.codesquad.secondhand.domain.token.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TokenRepository extends JpaRepository<RefreshToken, Long> {
+}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,39 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3309/second_hand
+    username: user
+    password: admin
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+
+jwt:
+  secret-key: 2901ujr9021urf0u902hf021y90fh9c210hg093hg091h3g90h30gh901hg09h01
+  access-token-expiration-time: 100000
+  refresh-token-expiration-time: 2000000
+
+cloud:
+  aws:
+    credentials:
+      access-key: access-key
+      secret-key: secret-key
+    s3:
+      bucket: bucket
+    region:
+      static: static
+    stack:
+      auto: false
+
+oauth2:
+  user:
+    client-id: client-id
+    client-secret: client-secret
+    redirect-url: redirect-url
+  provider:
+    token-url: token-url
+    user-info-url: user-info-url

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -27,6 +27,16 @@ CREATE TABLE IF NOT EXISTS `second_hand`.`member`
     PRIMARY KEY (`id`)
 ) ENGINE = InnoDB;
 
+-- -----------------------------------------------------
+-- Table `second_hand`.`refresh_token`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `second_hand`.`refresh_token`
+(
+    `member_id` BIGINT       NOT NULL,
+    `token`     VARCHAR(256) NOT NULL,
+    PRIMARY KEY (`member_id`)
+) ENGINE = InnoDB;
+
 
 -- -----------------------------------------------------
 -- Table `second_hand`.`item`

--- a/src/test/java/kr/codesquad/secondhand/DatabaseInitializer.java
+++ b/src/test/java/kr/codesquad/secondhand/DatabaseInitializer.java
@@ -1,0 +1,56 @@
+package kr.codesquad.secondhand;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.annotation.PostConstruct;
+import javax.persistence.EntityManager;
+import javax.sql.DataSource;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.util.HashSet;
+import java.util.Set;
+
+@Profile("test")
+@Component
+public class DatabaseInitializer {
+
+    private static final String TRUNCATE_QUERY = "TRUNCATE TABLE %s";
+    private static final String AUTO_INCREMENT_INIT_QUERY = "ALTER TABLE %s AUTO_INCREMENT = 1";
+
+    private final Set<String> tableNames = new HashSet<>();
+
+    @Autowired
+    private EntityManager em;
+    @Autowired
+    private DataSource dataSource;
+
+    @PostConstruct
+    public void collectTableNames() {
+        try {
+            DatabaseMetaData metaData = dataSource.getConnection().getMetaData();
+            ResultSet tables = metaData.getTables(null, null, null, new String[]{"TABLE"});
+            while (tables.next()) {
+                String tableName = tables.getString("TABLE_NAME");
+                tableNames.add(tableName);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("테이블 이름을 불러올 수 없습니다.");
+        }
+    }
+
+    @Transactional
+    public void truncateTables() {
+        em.createNativeQuery("SET FOREIGN_KEY_CHECKS = 0").executeUpdate();
+        for (String tableName : tableNames) {
+            em.createNativeQuery(String.format(TRUNCATE_QUERY, tableName)).executeUpdate();
+            if (tableName.equals("RUNNING_TASK")) {
+                return;
+            }
+            em.createNativeQuery(String.format(AUTO_INCREMENT_INIT_QUERY, tableName)).executeUpdate();
+        }
+        em.createNativeQuery("SET FOREIGN_KEY_CHECKS = 1").executeUpdate();
+    }
+}

--- a/src/test/java/kr/codesquad/secondhand/DatabaseInitializerExtension.java
+++ b/src/test/java/kr/codesquad/secondhand/DatabaseInitializerExtension.java
@@ -1,0 +1,15 @@
+package kr.codesquad.secondhand;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+public class DatabaseInitializerExtension implements AfterEachCallback {
+
+    @Override
+    public void afterEach(ExtensionContext context) {
+        DatabaseInitializer databaseInitializer = (DatabaseInitializer) SpringExtension.getApplicationContext(context)
+                .getBean("databaseInitializer");
+        databaseInitializer.truncateTables();
+    }
+}

--- a/src/test/java/kr/codesquad/secondhand/SupportRepository.java
+++ b/src/test/java/kr/codesquad/secondhand/SupportRepository.java
@@ -1,5 +1,6 @@
 package kr.codesquad.secondhand;
 
+import java.util.Optional;
 import javax.persistence.EntityManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
@@ -19,5 +20,10 @@ public class SupportRepository {
         em.flush();
         em.clear();
         return entity;
+    }
+
+    public <T> Optional<T> findById(Class<T> entityType, Object id) {
+        em.flush();
+        return Optional.ofNullable(em.find(entityType, id));
     }
 }

--- a/src/test/java/kr/codesquad/secondhand/SupportRepository.java
+++ b/src/test/java/kr/codesquad/secondhand/SupportRepository.java
@@ -1,0 +1,23 @@
+package kr.codesquad.secondhand;
+
+import javax.persistence.EntityManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Profile("test")
+@Component
+@Transactional
+public class SupportRepository {
+
+    @Autowired
+    private EntityManager em;
+
+    public <T> T save(T entity) {
+        em.persist(entity);
+        em.flush();
+        em.clear();
+        return entity;
+    }
+}

--- a/src/test/java/kr/codesquad/secondhand/TokenCreator.java
+++ b/src/test/java/kr/codesquad/secondhand/TokenCreator.java
@@ -1,0 +1,29 @@
+package kr.codesquad.secondhand;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import kr.codesquad.secondhand.infrastructure.jwt.JwtProvider;
+import kr.codesquad.secondhand.infrastructure.properties.JwtProperties;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+public class TokenCreator {
+
+    private static final String secretKey = "2901ujr9021urf0u902hf021y90fh9c210hg093hg091h3g90h30gh901hg09h01";
+    private static final JwtProvider jwtProvider = new JwtProvider(new JwtProperties(secretKey, 10000, 100000));
+
+    public static String createToken(Long payload) {
+        return jwtProvider.createAccessToken(payload);
+    }
+
+    public static String createExpiredToken(Long payload) {
+        Date now = new Date();
+        return Jwts.builder()
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() - 1))
+                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS256)
+                .compact();
+    }
+}

--- a/src/test/java/kr/codesquad/secondhand/application/ApplicationTest.java
+++ b/src/test/java/kr/codesquad/secondhand/application/ApplicationTest.java
@@ -1,0 +1,17 @@
+package kr.codesquad.secondhand.application;
+
+import kr.codesquad.secondhand.DatabaseInitializerExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@ExtendWith(DatabaseInitializerExtension.class)
+@SpringBootTest
+public @interface ApplicationTest {
+}

--- a/src/test/java/kr/codesquad/secondhand/application/auth/MemberServiceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/application/auth/MemberServiceTest.java
@@ -7,9 +7,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.anyString;
 import static org.mockito.BDDMockito.given;
 
+import java.util.Optional;
 import kr.codesquad.secondhand.SupportRepository;
 import kr.codesquad.secondhand.application.ApplicationTest;
 import kr.codesquad.secondhand.domain.member.Member;
+import kr.codesquad.secondhand.domain.token.RefreshToken;
 import kr.codesquad.secondhand.exception.ErrorCode;
 import kr.codesquad.secondhand.exception.UnAuthorizedException;
 import kr.codesquad.secondhand.presentation.dto.LoginRequest;
@@ -54,7 +56,9 @@ class MemberServiceTest {
             LoginResponse response = memberService.login(request, "code");
 
             // then
+            Optional<RefreshToken> token = supportRepository.findById(RefreshToken.class, 1L);
             assertAll(
+                    () -> assertThat(token).isPresent(),
                     () -> assertThat(response.getJwt().getAccessToken()).isNotBlank(),
                     () -> assertThat(response.getJwt().getRefreshToken()).isNotBlank(),
                     () -> assertThat(response.getUser().getLoginId()).isNotBlank(),

--- a/src/test/java/kr/codesquad/secondhand/application/auth/MemberServiceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/application/auth/MemberServiceTest.java
@@ -1,0 +1,107 @@
+package kr.codesquad.secondhand.application.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.anyString;
+import static org.mockito.BDDMockito.given;
+
+import kr.codesquad.secondhand.SupportRepository;
+import kr.codesquad.secondhand.application.ApplicationTest;
+import kr.codesquad.secondhand.domain.member.Member;
+import kr.codesquad.secondhand.exception.ErrorCode;
+import kr.codesquad.secondhand.exception.UnAuthorizedException;
+import kr.codesquad.secondhand.presentation.dto.LoginRequest;
+import kr.codesquad.secondhand.presentation.dto.LoginResponse;
+import kr.codesquad.secondhand.presentation.dto.OauthTokenResponse;
+import kr.codesquad.secondhand.presentation.dto.UserProfile;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@ApplicationTest
+class MemberServiceTest {
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private SupportRepository supportRepository;
+
+    @MockBean
+    private NaverRequester naverRequester;
+
+    @Nested
+    class Login {
+
+        @DisplayName("로그인 정보가 주어지면 로그인에 성공해 토큰정보와 유저 정보를 반환한다.")
+        @Test
+        void givenLoginData_whenLogin_thenSuccess() {
+            // given
+            mockingOAuthInfo();
+
+            LoginRequest request = new LoginRequest("joy");
+            supportRepository.save(Member.builder()
+                    .email("joy@naver.com")
+                    .loginId("joy")
+                    .profileUrl("url")
+                    .build());
+
+            // when
+            LoginResponse response = memberService.login(request, "code");
+
+            // then
+            assertAll(
+                    () -> assertThat(response.getJwt().getAccessToken()).isNotBlank(),
+                    () -> assertThat(response.getJwt().getRefreshToken()).isNotBlank(),
+                    () -> assertThat(response.getUser().getLoginId()).isNotBlank(),
+                    () -> assertThat(response.getUser().getProfileUrl()).isNotBlank()
+            );
+        }
+
+        @DisplayName("아이디는 존재하지만 해당 아이디의 이메일과 Naver 이메일 정보가 일치하지 않는 로그인 정보가 주어지면 예외를 던진다.")
+        @Test
+        void givenInvalidLoginData_whenLogin_thenThrowsException() {
+            // given
+            mockingOAuthInfo();
+
+            LoginRequest request = new LoginRequest("joy");
+            supportRepository.save(Member.builder()
+                    .email("joooy@naver.com")
+                    .loginId("joy")
+                    .profileUrl("url")
+                    .build());
+
+            // when & then
+            assertThatThrownBy(() -> memberService.login(request, "code"))
+                    .isInstanceOf(UnAuthorizedException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.INVALID_LOGIN_DATA);
+        }
+
+        @DisplayName("아이디가 존재하지 않아 로그인할 때 예외를 던진다.")
+        @Test
+        void givenNotExistsLoginId_whenLogin_thenThrowsException() {
+            // given
+            mockingOAuthInfo();
+            LoginRequest request = new LoginRequest("joy");
+
+            // when & then
+            assertThatThrownBy(() -> memberService.login(request, "code"))
+                    .isInstanceOf(UnAuthorizedException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.INVALID_LOGIN_DATA);
+        }
+
+        private void mockingOAuthInfo() {
+            given(naverRequester.getToken(anyString()))
+                    .willReturn(new OauthTokenResponse("a.a.a", "scope", "bearer"));
+            given(naverRequester.getUserProfile(any(OauthTokenResponse.class)))
+                    .willReturn(UserProfile.builder()
+                            .email("joy@naver.com")
+                            .profileUrl("url")
+                            .build());
+        }
+    }
+}

--- a/src/test/java/kr/codesquad/secondhand/application/auth/TokenServiceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/application/auth/TokenServiceTest.java
@@ -1,0 +1,70 @@
+package kr.codesquad.secondhand.application.auth;
+
+import kr.codesquad.secondhand.SupportRepository;
+import kr.codesquad.secondhand.TokenCreator;
+import kr.codesquad.secondhand.application.ApplicationTest;
+import kr.codesquad.secondhand.domain.token.RefreshToken;
+import kr.codesquad.secondhand.exception.ErrorCode;
+import kr.codesquad.secondhand.exception.UnAuthorizedException;
+import kr.codesquad.secondhand.infrastructure.jwt.JwtProvider;
+import kr.codesquad.secondhand.presentation.dto.token.AccessTokenResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ApplicationTest
+class TokenServiceTest {
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private SupportRepository supportRepository;
+
+    @Autowired
+    private TokenService tokenService;
+
+    @DisplayName("리프레시 토큰을 통해 액세스 토큰을 갱신하는데 성공한다.")
+    @Test
+    void givenRefreshToken_whenRenewAccessToken_thenSuccess() {
+        // given
+        String refreshToken = jwtProvider.createRefreshToken(1L);
+        supportRepository.save(RefreshToken.builder()
+                .memberId(1L)
+                .token(refreshToken)
+                .build());
+
+        // when
+        AccessTokenResponse result = tokenService.renewAccessToken(refreshToken);
+
+        // then
+        assertThat(result.getAccessToken()).isNotBlank();
+    }
+
+    @DisplayName("만료된 토큰이 주어지면 토큰을 갱신할 때 에외를 던진다.")
+    @Test
+    void givenExpiredToken_whenRenewAccessToken_thenThrowsException() {
+        // given
+        String expiredToken = TokenCreator.createExpiredToken(1L);
+
+        // when & then
+        assertThatThrownBy(() -> tokenService.renewAccessToken(expiredToken))
+                .isInstanceOf(UnAuthorizedException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.EXPIRED_TOKEN);
+    }
+
+    @DisplayName("존재하지 않는 리프레시 토큰이 주어지면 토큰을 갱신할 때 예외를 던진다.")
+    @Test
+    void givenNotExistsRefreshToken_whenRenewAccessToken_thenThrowsException() {
+        // given
+        String token = TokenCreator.createToken(1L);
+
+        // when & then
+        assertThatThrownBy(() -> tokenService.renewAccessToken(token))
+                .isInstanceOf(UnAuthorizedException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.INVALID_TOKEN);
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,16 +1,4 @@
 spring:
-  datasource:
-    url: jdbc:mysql://localhost:3309/second_hand
-    username: user
-    password: admin
-
-  jpa:
-    properties:
-      hibernate:
-        show_sql: true
-        format_sql: true
-
-jwt:
-  secret-key: 2901ujr9021urf0u902hf021y90fh9c210hg093hg091h3g90h30gh901hg09h01
-  access-token-expiration-time: 100000
-  refresh-token-expiration-time: 2000000
+  profiles:
+    active:
+      - test


### PR DESCRIPTION
## Issues
- #12 

## What is this PR? 👓
- 리프레시 토큰 갱신 기능에 대한 PR
- 로그인 성공시 토큰 (액세스토큰, 리프레시토큰) 발급 기능에 대한 PR

## Key changes 🔑
- `리프레시 토큰` 저장을 위한 테이블 생성 -> schema.sql
- `리프레시 토큰` 발급로직 작성 (기존 액세스 토큰과 동일)
- `리프레시 토큰`을 통한 `액세스 토큰` 갱신 기능구현
- 로그인 성공시 `액세스 토큰`, `리프레시 토큰`
- 테스트코드 작성
  - 독립된 테스트 환경을 구성하기 위한 `DatabaseInitializer` 클래스 작성
  - 애노테이션을 통해 이를 구현하기 위해 `DatabaseInitializerExtension` 클래스 작성
  - 애플리케이션-레포지토리 레이어 테스트 코드 작성

## To reviewers 👋
- 리프레시 토큰을 위한 테이블 스키마를 확인해주세요!
- `MemberService` 클래스의 예외처리 todo 부분을 처리했습니다.
- 2주차부터 `RestAssured`를 통해 테스트코드 작성해보겠습니다!