### PR TITLE
회원 정보를 가져오는 AOP

### DIFF
--- a/src/main/java/kr/codesquad/secondhand/config/FilterConfig.java
+++ b/src/main/java/kr/codesquad/secondhand/config/FilterConfig.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.codesquad.secondhand.infrastructure.jwt.JwtProvider;
 import kr.codesquad.secondhand.presentation.filter.AuthExceptionHandlerFilter;
 import kr.codesquad.secondhand.presentation.filter.JwtFilter;
+import kr.codesquad.secondhand.presentation.support.AuthenticationContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
@@ -14,12 +15,13 @@ import org.springframework.context.annotation.Configuration;
 public class FilterConfig {
 
     private final JwtProvider jwtProvider;
+    private final AuthenticationContext authenticationContext;
     private final ObjectMapper objectMapper;
 
     @Bean
     public FilterRegistrationBean<JwtFilter> jwtFilter() {
         FilterRegistrationBean<JwtFilter> jwtFilter = new FilterRegistrationBean<>();
-        jwtFilter.setFilter(new JwtFilter(jwtProvider));
+        jwtFilter.setFilter(new JwtFilter(jwtProvider, authenticationContext));
         jwtFilter.addUrlPatterns("/api/*");
         jwtFilter.setOrder(2);
         return jwtFilter;

--- a/src/main/java/kr/codesquad/secondhand/config/WebConfig.java
+++ b/src/main/java/kr/codesquad/secondhand/config/WebConfig.java
@@ -1,0 +1,20 @@
+package kr.codesquad.secondhand.config;
+
+import java.util.List;
+import kr.codesquad.secondhand.presentation.support.AuthArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthArgumentResolver authArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authArgumentResolver);
+    }
+}

--- a/src/main/java/kr/codesquad/secondhand/exception/ErrorCode.java
+++ b/src/main/java/kr/codesquad/secondhand/exception/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
     // AUTH
     INVALID_LOGIN_DATA("로그인 정보가 일치하지 않습니다."),
     DUPLICATED_LOGIN_ID("중복된 아이디입니다."),
+    NOT_LOGIN("로그인된 상태가 아닙니다."),
 
     // COMMON
     INVALID_PARAMETER("유효한 파라미터값이 아닙니다.");

--- a/src/main/java/kr/codesquad/secondhand/presentation/filter/JwtFilter.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/filter/JwtFilter.java
@@ -1,21 +1,21 @@
 package kr.codesquad.secondhand.presentation.filter;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import kr.codesquad.secondhand.exception.ErrorCode;
 import kr.codesquad.secondhand.exception.UnAuthorizedException;
 import kr.codesquad.secondhand.infrastructure.jwt.JwtProvider;
+import kr.codesquad.secondhand.presentation.support.AuthenticationContext;
 import org.springframework.http.HttpHeaders;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.StringUtils;
 import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
-
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.util.List;
-import java.util.Optional;
 
 public class JwtFilter extends OncePerRequestFilter {
 
@@ -25,9 +25,11 @@ public class JwtFilter extends OncePerRequestFilter {
     private final List<String> excludeUrlPatterns = List.of("/api/auth/**");
 
     private final JwtProvider jwtProvider;
+    private final AuthenticationContext authenticationContext;
 
-    public JwtFilter(JwtProvider jwtProvider) {
+    public JwtFilter(JwtProvider jwtProvider, AuthenticationContext authenticationContext) {
         this.jwtProvider = jwtProvider;
+        this.authenticationContext = authenticationContext;
     }
 
     @Override
@@ -48,6 +50,7 @@ public class JwtFilter extends OncePerRequestFilter {
         String token = extractJwt(request)
                 .orElseThrow(() -> new UnAuthorizedException(ErrorCode.INVALID_AUTH_HEADER));
         jwtProvider.validateToken(token);
+        authenticationContext.setMemberId(jwtProvider.extractClaims(token));
 
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/kr/codesquad/secondhand/presentation/support/Auth.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/support/Auth.java
@@ -1,0 +1,11 @@
+package kr.codesquad.secondhand.presentation.support;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Auth {
+}

--- a/src/main/java/kr/codesquad/secondhand/presentation/support/AuthArgumentResolver.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/support/AuthArgumentResolver.java
@@ -1,0 +1,31 @@
+package kr.codesquad.secondhand.presentation.support;
+
+import kr.codesquad.secondhand.exception.ErrorCode;
+import kr.codesquad.secondhand.exception.UnAuthorizedException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@RequiredArgsConstructor
+@Component
+public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final AuthenticationContext authenticationContext;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(Auth.class)
+                && parameter.getParameterType().equals(Long.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        return authenticationContext.getMemberId()
+                .orElseThrow(() -> new UnAuthorizedException(ErrorCode.NOT_LOGIN));
+    }
+}

--- a/src/main/java/kr/codesquad/secondhand/presentation/support/AuthenticationContext.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/support/AuthenticationContext.java
@@ -1,0 +1,21 @@
+package kr.codesquad.secondhand.presentation.support;
+
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
+
+@Component
+@RequestScope
+public class AuthenticationContext {
+
+    private Long memberId;
+
+    public Optional<Long> getMemberId() {
+        return Optional.ofNullable(memberId);
+    }
+
+    public void setMemberId(Map<String, Object> claims) {
+        this.memberId = Long.valueOf(claims.get("memberId").toString());
+    }
+}


### PR DESCRIPTION
## Issues
- #18 

## What is this PR? 👓
현재 로그인된 사용자의 id(PK)를 가져오는 기능에 대한 PR입니다.

## Key changes 🔑
- `@Auth` 애노테이션을 생성하고 이를 통해 쉽게 현재 로그인된 사용자의 PK를 가져올 수 있도록 구현했습니다.
- `ArgumentResolver`를 통해 파라미터에 붙은 `@Auth`을 resolve할 수 있도록 했습니다.
- `AuthenticationContext` 클래스에 현재 멤버 아이디(PK)를 담았습니다.
  - 해당 클래스는 `@RequestScope` 애노테이션을 이용해 요청이 생성될 때마다 빈이 생성되어 등록되도록 했습니다.
  - https://chung-develop.tistory.com/64

## To reviewers 👋
이후에 현재 로그인된 사용자의 PK를 가져오고 싶다면 `@Auth` 애노테이션을 사용하면 좋을 것 같습니당!
