### PR TITLE
회원가입시 주소, 프로필 사진 저장

### DIFF
--- a/src/main/java/kr/codesquad/secondhand/application/auth/AuthService.java
+++ b/src/main/java/kr/codesquad/secondhand/application/auth/AuthService.java
@@ -1,6 +1,7 @@
 package kr.codesquad.secondhand.application.auth;
 
 import kr.codesquad.secondhand.domain.member.Member;
+import kr.codesquad.secondhand.domain.residence.Residence;
 import kr.codesquad.secondhand.domain.token.RefreshToken;
 import kr.codesquad.secondhand.exception.DuplicatedException;
 import kr.codesquad.secondhand.exception.ErrorCode;
@@ -14,6 +15,7 @@ import kr.codesquad.secondhand.presentation.dto.UserProfile;
 import kr.codesquad.secondhand.presentation.dto.UserResponse;
 import kr.codesquad.secondhand.presentation.dto.token.AuthToken;
 import kr.codesquad.secondhand.repository.member.MemberRepository;
+import kr.codesquad.secondhand.repository.residence.ResidenceRepository;
 import kr.codesquad.secondhand.repository.token.TokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,6 +28,7 @@ public class AuthService {
 
     private final TokenRepository tokenRepository;
     private final MemberRepository memberRepository;
+    private final ResidenceRepository residenceRepository;
     private final NaverRequester naverRequester;
     private final JwtProvider jwtProvider;
 
@@ -51,8 +54,9 @@ public class AuthService {
         verifyDuplicated(request);
         OauthTokenResponse tokenResponse = naverRequester.getToken(code);
         UserProfile userProfile = naverRequester.getUserProfile(tokenResponse);
-        saveMember(request, userProfile);
-        // todo: 주소 저장 로직 필요
+        Member savedMember = saveMember(request, userProfile);
+        saveResidence(request, savedMember);
+
     }
 
     private Long verifyUser(LoginRequest request, UserProfile userProfile) {
@@ -72,5 +76,9 @@ public class AuthService {
 
     private Member saveMember(SignUpRequest request, UserProfile userProfile) {
         return memberRepository.save(Member.toEntity(request, userProfile));
+    }
+
+    private Residence saveResidence(SignUpRequest request, Member member) {
+        return residenceRepository.save(Residence.toEntity(request, member));
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/application/auth/AuthService.java
+++ b/src/main/java/kr/codesquad/secondhand/application/auth/AuthService.java
@@ -20,6 +20,7 @@ import kr.codesquad.secondhand.repository.token.TokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -50,10 +51,13 @@ public class AuthService {
     }
 
     @Transactional
-    public void signUp(SignUpRequest request, String code) {
+    public void signUp(SignUpRequest request, String code, MultipartFile profile) {
         verifyDuplicated(request);
         OauthTokenResponse tokenResponse = naverRequester.getToken(code);
         UserProfile userProfile = naverRequester.getUserProfile(tokenResponse);
+        if (profile != null && !profile.isEmpty()) {
+            userProfile.changeProfileUrl(profile);
+        }
         Member savedMember = saveMember(request, userProfile);
         saveResidence(request, savedMember);
 

--- a/src/main/java/kr/codesquad/secondhand/application/auth/NaverRequester.java
+++ b/src/main/java/kr/codesquad/secondhand/application/auth/NaverRequester.java
@@ -25,10 +25,10 @@ public class NaverRequester {
     private final OauthProvider oauthProvider;
     private final String DEFAULT_PROFILE_IMAGE;
 
-    public NaverRequester(RestTemplate restTemplate, OauthProvider oauthProvider, @Value("${custom.default-profile}") String DEFAULT_PROFILE_IMAGE) {
+    public NaverRequester(RestTemplate restTemplate, OauthProvider oauthProvider, @Value("${custom.default-profile}") String defaultProfileImage) {
         this.restTemplate = restTemplate;
         this.oauthProvider = oauthProvider;
-        this.DEFAULT_PROFILE_IMAGE = DEFAULT_PROFILE_IMAGE;
+        this.DEFAULT_PROFILE_IMAGE = defaultProfileImage;
     }
 
     public OauthTokenResponse getToken(String code) {

--- a/src/main/java/kr/codesquad/secondhand/application/auth/NaverRequester.java
+++ b/src/main/java/kr/codesquad/secondhand/application/auth/NaverRequester.java
@@ -6,7 +6,7 @@ import java.util.Map;
 import kr.codesquad.secondhand.infrastructure.OauthProvider;
 import kr.codesquad.secondhand.presentation.dto.OauthTokenResponse;
 import kr.codesquad.secondhand.presentation.dto.UserProfile;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -18,12 +18,18 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
-@RequiredArgsConstructor
 @Component
 public class NaverRequester {
 
     private final RestTemplate restTemplate;
     private final OauthProvider oauthProvider;
+    private final String DEFAULT_PROFILE_IMAGE;
+
+    public NaverRequester(RestTemplate restTemplate, OauthProvider oauthProvider, @Value("${custom.default-profile}") String DEFAULT_PROFILE_IMAGE) {
+        this.restTemplate = restTemplate;
+        this.oauthProvider = oauthProvider;
+        this.DEFAULT_PROFILE_IMAGE = DEFAULT_PROFILE_IMAGE;
+    }
 
     public OauthTokenResponse getToken(String code) {
         HttpHeaders headers = new HttpHeaders();
@@ -56,7 +62,7 @@ public class NaverRequester {
         Map<String, Object> userAttributes = (Map<String, Object>) responseAttributes.get("response");
         return UserProfile.builder()
                 .email((String) userAttributes.get("email"))
-                .profileUrl((String) userAttributes.get("profile_image"))
+                .profileUrl(DEFAULT_PROFILE_IMAGE)
                 .build();
     }
 

--- a/src/main/java/kr/codesquad/secondhand/domain/member/Member.java
+++ b/src/main/java/kr/codesquad/secondhand/domain/member/Member.java
@@ -33,7 +33,7 @@ public class Member {
     private String profileUrl;
 
     @Builder
-    private Member(Long id, String loginId, String email, String profileUrl) {
+    public Member(Long id, String loginId, String email, String profileUrl) {
         this.id = id;
         this.loginId = loginId;
         this.email = email;

--- a/src/main/java/kr/codesquad/secondhand/domain/residence/Residence.java
+++ b/src/main/java/kr/codesquad/secondhand/domain/residence/Residence.java
@@ -1,0 +1,48 @@
+package kr.codesquad.secondhand.domain.residence;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import kr.codesquad.secondhand.domain.member.Member;
+import kr.codesquad.secondhand.presentation.dto.SignUpRequest;
+import kr.codesquad.secondhand.presentation.dto.UserProfile;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "residence")
+@Entity
+public class Residence {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 45, nullable = false, name = "addr_name")
+    private String addrName;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Builder
+    public Residence(Long id, String addrName, Member member) {
+        this.id = id;
+        this.addrName = addrName;
+        this.member = member;
+    }
+
+    public static Residence toEntity(SignUpRequest request, Member member) {
+        return Residence.builder()
+                .addrName(request.getAddrName())
+                .member(member)
+                .build();
+    }
+}

--- a/src/main/java/kr/codesquad/secondhand/domain/residence/Residence.java
+++ b/src/main/java/kr/codesquad/secondhand/domain/residence/Residence.java
@@ -2,6 +2,7 @@ package kr.codesquad.secondhand.domain.residence;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -22,13 +23,14 @@ import lombok.NoArgsConstructor;
 @Entity
 public class Residence {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(length = 45, nullable = false, name = "addr_name")
+    @Column(length = 45, nullable = false)
     private String addrName;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/src/main/java/kr/codesquad/secondhand/presentation/AuthController.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/AuthController.java
@@ -50,7 +50,7 @@ public class AuthController {
     public ResponseEntity<ApiResponse<Void>> signUp(@RequestBody @Valid SignUpRequest request,
                                                     @RequestParam Optional<String> code,
                                                     @RequestParam Optional<String> state,
-                                                    @RequestPart(required = false) Optional<MultipartFile> profile) {
+                                                    @RequestPart Optional<MultipartFile> profile) {
         authService.signUp(request,
                 code.orElseThrow(() -> new BadRequestException(ErrorCode.INVALID_PARAMETER)),
                 profile);

--- a/src/main/java/kr/codesquad/secondhand/presentation/AuthController.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/AuthController.java
@@ -31,7 +31,6 @@ public class AuthController {
 
     private final AuthService authService;
     private final TokenService tokenService;
-    private final ImageService imageService;
 
     @PostMapping("/naver/login")
     public ResponseEntity<ApiResponse<LoginResponse>> login(@RequestBody @Valid LoginRequest request,
@@ -51,11 +50,10 @@ public class AuthController {
     public ResponseEntity<ApiResponse<Void>> signUp(@RequestBody @Valid SignUpRequest request,
                                                     @RequestParam Optional<String> code,
                                                     @RequestParam Optional<String> state,
-                                                    @RequestPart(required = false) MultipartFile profile) {
-        if (profile != null && !profile.isEmpty()) {
-            imageService.uploadImage(profile);
-        }
-        authService.signUp(request, code.orElseThrow(() -> new BadRequestException(ErrorCode.INVALID_PARAMETER)), profile);
+                                                    @RequestPart(required = false) Optional<MultipartFile> profile) {
+        authService.signUp(request,
+                code.orElseThrow(() -> new BadRequestException(ErrorCode.INVALID_PARAMETER)),
+                profile);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(new ApiResponse<>(HttpStatus.CREATED.value()));
     }

--- a/src/main/java/kr/codesquad/secondhand/presentation/dto/UserProfile.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/dto/UserProfile.java
@@ -17,11 +17,7 @@ public class UserProfile {
         this.profileUrl = profileUrl;
     }
 
-    public void changeProfileUrl(MultipartFile file) {
-        try {
-            this.profileUrl = file.getBytes().toString();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+    public void setProfileUrl(String profileUrl) {
+        this.profileUrl = profileUrl;
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/presentation/dto/UserProfile.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/dto/UserProfile.java
@@ -1,17 +1,27 @@
 package kr.codesquad.secondhand.presentation.dto;
 
+import java.io.IOException;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 public class UserProfile {
 
     private final String email;
-    private final String profileUrl;
+    private String profileUrl;
 
     @Builder
     public UserProfile(String email, String profileUrl) {
         this.email = email;
         this.profileUrl = profileUrl;
+    }
+
+    public void changeProfileUrl(MultipartFile file) {
+        try {
+            this.profileUrl = file.getBytes().toString();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/repository/residence/ResidenceRepository.java
+++ b/src/main/java/kr/codesquad/secondhand/repository/residence/ResidenceRepository.java
@@ -1,0 +1,7 @@
+package kr.codesquad.secondhand.repository.residence;
+
+import kr.codesquad.secondhand.domain.residence.Residence;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ResidenceRepository extends JpaRepository<Residence, Long> {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,3 +5,6 @@ spring:
     include:
       - oauth
       - secret
+custom:
+  default-profile:
+    https://e7.pngegg.com/pngimages/1000/665/png-clipart-computer-icons-profile-s-free-angle-sphere.png


### PR DESCRIPTION
## Issues
- #17 

## What is this PR? 👓
회원가입시 주소, 프로필 사진 저장

## Key changes 🔑
- 회원가입 시 주소를 저장한다.
- 회원가입 시 등록한 프로필 사진을 S3에 저장하고 db에 저장한다.
- 회원가입 시 등록한 프로필 사진이 없다면 S3에는 저장하지 않고, db에 기본프로필사진을 저장한다.

## To reviewers 👋
이미지url을 `MultipartFile`로 변환하는 방법을 못찾아서 회원가입 시 등록한 프로필 사진이 없다면 S3에는 저장하지 않았는데 어떻게 생각하세요?:)