### PR TITLE
상품 등록

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
 
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.rest-assured:rest-assured:4.5.1'
 
     // validation
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation'

--- a/src/main/java/kr/codesquad/secondhand/application/item/ItemService.java
+++ b/src/main/java/kr/codesquad/secondhand/application/item/ItemService.java
@@ -1,0 +1,42 @@
+package kr.codesquad.secondhand.application.item;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import kr.codesquad.secondhand.application.image.ImageService;
+import kr.codesquad.secondhand.domain.item.Item;
+import kr.codesquad.secondhand.domain.itemimage.ItemImage;
+import kr.codesquad.secondhand.domain.member.Member;
+import kr.codesquad.secondhand.presentation.dto.item.ItemRegisterRequest;
+import kr.codesquad.secondhand.repository.item.ItemRepository;
+import kr.codesquad.secondhand.repository.itemimage.ItemImageRepository;
+import kr.codesquad.secondhand.repository.member.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class ItemService {
+
+    private final ImageService imageService;
+    private final ItemRepository itemRepository;
+    private final ItemImageRepository itemImageRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void register(List<MultipartFile> images, ItemRegisterRequest request, Long sellerId) {
+        List<String> itemImageUrls = imageService.uploadImages(images);
+        String thumbnailUrl = itemImageUrls.get(0);
+
+        Member seller = memberRepository.getReferenceById(sellerId);
+
+        Item savedItem = itemRepository.save(Item.toEntity(request, seller, thumbnailUrl));
+
+        List<ItemImage> itemImages = itemImageUrls.stream()
+                .map(url -> ItemImage.toEntity(url, savedItem))
+                .collect(Collectors.toList());
+        itemImageRepository.saveAllItemImages(itemImages);
+    }
+}

--- a/src/main/java/kr/codesquad/secondhand/config/JpaAuditingConfig.java
+++ b/src/main/java/kr/codesquad/secondhand/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package kr.codesquad.secondhand.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaAuditingConfig {
+}

--- a/src/main/java/kr/codesquad/secondhand/domain/AuditingFields.java
+++ b/src/main/java/kr/codesquad/secondhand/domain/AuditingFields.java
@@ -1,0 +1,22 @@
+package kr.codesquad.secondhand.domain;
+
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class AuditingFields {
+
+    @DateTimeFormat(iso = ISO.DATE_TIME)
+    @Column(nullable = false, updatable = false)
+    @CreatedDate
+    protected LocalDateTime createdAt;
+}

--- a/src/main/java/kr/codesquad/secondhand/domain/item/Item.java
+++ b/src/main/java/kr/codesquad/secondhand/domain/item/Item.java
@@ -1,0 +1,98 @@
+package kr.codesquad.secondhand.domain.item;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import kr.codesquad.secondhand.domain.AuditingFields;
+import kr.codesquad.secondhand.domain.member.Member;
+import kr.codesquad.secondhand.presentation.dto.item.ItemRegisterRequest;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DynamicInsert
+@Table(name = "item")
+@Entity
+public class Item extends AuditingFields {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 100, nullable = false)
+    private String title;
+
+    @Column(length = 2000)
+    private String content;
+
+    @Column
+    private Integer price;
+
+    @Column(length = 100, nullable = false)
+    private String tradingRegion;
+
+    @Column(nullable = false)
+    @ColumnDefault(value = "0")
+    private Integer viewCount;
+
+    @Column(nullable = false)
+    @ColumnDefault(value = "0")
+    private Integer wishCount;
+
+    @Column(nullable = false)
+    @ColumnDefault(value = "0")
+    private Integer chatCount;
+
+    @Column(length = 45, nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ItemStatus status;
+
+    @Column(length = 45, nullable = false)
+    private String categoryName;
+
+    @Column(length = 512, nullable = false)
+    private String thumbnailUrl;
+
+    @JoinColumn(name = "seller_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    @Builder
+    private Item(String title, String content, Integer price, String tradingRegion,
+                 ItemStatus status, String categoryName, String thumbnailUrl, Member member) {
+        this.title = title;
+        this.content = content;
+        this.price = price;
+        this.tradingRegion = tradingRegion;
+        this.status = status;
+        this.categoryName = categoryName;
+        this.thumbnailUrl = thumbnailUrl;
+        this.member = member;
+    }
+
+    public static Item toEntity(ItemRegisterRequest request, Member member, String thumbnailUrl) {
+        return Item.builder()
+                .title(request.getTitle())
+                .content(request.getContent())
+                .price(request.getPrice())
+                .tradingRegion(request.getRegion())
+                .status(ItemStatus.of(request.getStatus()))
+                .categoryName(request.getCategoryName())
+                .thumbnailUrl(thumbnailUrl)
+                .member(member)
+                .build();
+    }
+}

--- a/src/main/java/kr/codesquad/secondhand/domain/item/ItemStatus.java
+++ b/src/main/java/kr/codesquad/secondhand/domain/item/ItemStatus.java
@@ -1,0 +1,25 @@
+package kr.codesquad.secondhand.domain.item;
+
+import java.util.Arrays;
+import kr.codesquad.secondhand.exception.BadRequestException;
+import kr.codesquad.secondhand.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum ItemStatus {
+
+    ON_SALE("판매중"), SOLD_OUT("판매완료"), RESERVED("예약중");
+
+    private final String status;
+
+    public static ItemStatus of(String statusName) {
+        return Arrays.stream(ItemStatus.values())
+                .filter(itemStatus -> itemStatus.getStatus().equals(statusName))
+                .findFirst()
+                .orElseThrow(() -> new BadRequestException(
+                        ErrorCode.INVALID_REQUEST,
+                        "상품 판매 상태는 (판매중, 판매완료, 예약중) 만 들어올 수 있습니다."));
+    }
+}

--- a/src/main/java/kr/codesquad/secondhand/domain/itemimage/ItemImage.java
+++ b/src/main/java/kr/codesquad/secondhand/domain/itemimage/ItemImage.java
@@ -1,0 +1,47 @@
+package kr.codesquad.secondhand.domain.itemimage;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import kr.codesquad.secondhand.domain.item.Item;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "item_image")
+@Entity
+public class ItemImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 512, nullable = false)
+    private String imageUrl;
+
+    @JoinColumn(name = "item_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Item item;
+
+    @Builder
+    private ItemImage(String imageUrl, Item item) {
+        this.imageUrl = imageUrl;
+        this.item = item;
+    }
+
+    public static ItemImage toEntity(String imageUrl, Item item) {
+        return ItemImage.builder()
+                .imageUrl(imageUrl)
+                .item(item)
+                .build();
+    }
+}

--- a/src/main/java/kr/codesquad/secondhand/exception/ErrorCode.java
+++ b/src/main/java/kr/codesquad/secondhand/exception/ErrorCode.java
@@ -23,7 +23,8 @@ public enum ErrorCode {
     NOT_LOGIN("로그인된 상태가 아닙니다."),
 
     // COMMON
-    INVALID_PARAMETER("유효한 파라미터값이 아닙니다.");
+    INVALID_PARAMETER("유효한 파라미터값이 아닙니다."),
+    INVALID_REQUEST("유효한 요청이 아닙니다.");
 
     private final String message;
 }

--- a/src/main/java/kr/codesquad/secondhand/presentation/ItemController.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/ItemController.java
@@ -1,0 +1,44 @@
+package kr.codesquad.secondhand.presentation;
+
+import java.util.List;
+import java.util.Optional;
+import javax.validation.Valid;
+import kr.codesquad.secondhand.application.item.ItemService;
+import kr.codesquad.secondhand.exception.BadRequestException;
+import kr.codesquad.secondhand.exception.ErrorCode;
+import kr.codesquad.secondhand.presentation.dto.ApiResponse;
+import kr.codesquad.secondhand.presentation.dto.item.ItemRegisterRequest;
+import kr.codesquad.secondhand.presentation.support.Auth;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/items")
+@RestController
+public class ItemController {
+
+    private final ItemService itemService;
+
+    @PostMapping(consumes = {
+            MediaType.MULTIPART_FORM_DATA_VALUE,
+            MediaType.APPLICATION_JSON_VALUE
+    })
+    public ResponseEntity<ApiResponse<Void>> registerItem(@RequestPart Optional<List<MultipartFile>> images,
+                                                          @Valid @RequestPart ItemRegisterRequest item,
+                                                          @Auth Long memberId) {
+        itemService.register(
+                images.orElseThrow(() -> new BadRequestException(
+                        ErrorCode.INVALID_PARAMETER, "이미지는 최소 1개이상 들어와야 합니다.")),
+                item,
+                memberId);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new ApiResponse<>(HttpStatus.CREATED.value()));
+    }
+}

--- a/src/main/java/kr/codesquad/secondhand/presentation/dto/item/ItemRegisterRequest.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/dto/item/ItemRegisterRequest.java
@@ -1,0 +1,35 @@
+package kr.codesquad.secondhand.presentation.dto.item;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ItemRegisterRequest {
+
+    @NotBlank(message = "상품의 제목은 비어있을 수 없습니다.")
+    @Size(max = 100, message = "상품 제목의 길이는 100자를 넘을 수 없습니다.")
+    private String title;
+
+    private Integer price;
+
+    @Size(max = 2000, message = "상품 내용의 길이는 2000자를 넘을 수 없습니다.")
+    private String content;
+
+    @NotBlank(message = "상품의 판매 지역은 비어있을 수 없습니다.")
+    private String region;
+
+    @NotBlank(message = "상품의 판매 상태는 비어있을 수 없습니다.")
+    private String status;
+
+    @NotNull(message = "상품의 카테고리 아이디를 포함해 요청해주세요.")
+    private Integer categoryId;
+
+    @NotBlank(message = "상품의 카테고리 이름은 비어있을 수 없습니다.")
+    private String categoryName;
+}

--- a/src/main/java/kr/codesquad/secondhand/repository/item/ItemRepository.java
+++ b/src/main/java/kr/codesquad/secondhand/repository/item/ItemRepository.java
@@ -1,0 +1,7 @@
+package kr.codesquad.secondhand.repository.item;
+
+import kr.codesquad.secondhand.domain.item.Item;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ItemRepository extends JpaRepository<Item, Long> {
+}

--- a/src/main/java/kr/codesquad/secondhand/repository/itemimage/ItemImageRepository.java
+++ b/src/main/java/kr/codesquad/secondhand/repository/itemimage/ItemImageRepository.java
@@ -1,0 +1,7 @@
+package kr.codesquad.secondhand.repository.itemimage;
+
+import kr.codesquad.secondhand.domain.itemimage.ItemImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ItemImageRepository extends JpaRepository<ItemImage, Long>, ItemImageRepositoryCustom {
+}

--- a/src/main/java/kr/codesquad/secondhand/repository/itemimage/ItemImageRepositoryCustom.java
+++ b/src/main/java/kr/codesquad/secondhand/repository/itemimage/ItemImageRepositoryCustom.java
@@ -1,0 +1,9 @@
+package kr.codesquad.secondhand.repository.itemimage;
+
+import java.util.List;
+import kr.codesquad.secondhand.domain.itemimage.ItemImage;
+
+public interface ItemImageRepositoryCustom {
+
+    void saveAllItemImages(List<ItemImage> itemImages);
+}

--- a/src/main/java/kr/codesquad/secondhand/repository/itemimage/ItemImageRepositoryImpl.java
+++ b/src/main/java/kr/codesquad/secondhand/repository/itemimage/ItemImageRepositoryImpl.java
@@ -1,0 +1,28 @@
+package kr.codesquad.secondhand.repository.itemimage;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import kr.codesquad.secondhand.domain.itemimage.ItemImage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+@RequiredArgsConstructor
+public class ItemImageRepositoryImpl implements ItemImageRepositoryCustom {
+
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    @Override
+    public void saveAllItemImages(List<ItemImage> itemImages) {
+        // IDENTITY 방식의 한계로 bulk insert query 직접 구현
+        String sql = "INSERT INTO item_image "
+                + "(image_url, item_id) VALUES (:imageUrl, :itemId)";
+        MapSqlParameterSource[] params = itemImages.stream()
+                .map(itemImage -> new MapSqlParameterSource()
+                        .addValue("imageUrl", itemImage.getImageUrl())
+                        .addValue("itemId", itemImage.getItem().getId()))
+                .collect(Collectors.toList())
+                .toArray(MapSqlParameterSource[]::new);
+        jdbcTemplate.batchUpdate(sql, params);
+    }
+}

--- a/src/test/java/kr/codesquad/secondhand/SupportRepository.java
+++ b/src/test/java/kr/codesquad/secondhand/SupportRepository.java
@@ -1,5 +1,6 @@
 package kr.codesquad.secondhand;
 
+import java.util.List;
 import java.util.Optional;
 import javax.persistence.EntityManager;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,5 +26,12 @@ public class SupportRepository {
     public <T> Optional<T> findById(Class<T> entityType, Object id) {
         em.flush();
         return Optional.ofNullable(em.find(entityType, id));
+    }
+
+    public <T> List<T> findAll(Class<T> entityTypes) {
+        em.flush();
+        String entityTypeName = entityTypes.getSimpleName();
+        return em.createQuery(String.format("SELECT entity FROM %s entity", entityTypeName))
+                .getResultList();
     }
 }

--- a/src/test/java/kr/codesquad/secondhand/acceptance/ItemAcceptanceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/acceptance/ItemAcceptanceTest.java
@@ -1,0 +1,131 @@
+package kr.codesquad.secondhand.acceptance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.anyList;
+import static org.mockito.BDDMockito.given;
+
+import com.fasterxml.jackson.core.json.JsonWriteFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import kr.codesquad.secondhand.SupportRepository;
+import kr.codesquad.secondhand.application.image.S3Uploader;
+import kr.codesquad.secondhand.domain.member.Member;
+import kr.codesquad.secondhand.fixture.FixtureFactory;
+import kr.codesquad.secondhand.infrastructure.jwt.JwtProvider;
+import org.apache.http.HttpHeaders;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+
+@SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
+public class ItemAcceptanceTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private SupportRepository supportRepository;
+
+    @MockBean
+    private S3Uploader s3Uploader;
+
+    private File createFakeFile() throws IOException {
+        return File.createTempFile("test-image", ".png");
+    }
+
+    @DisplayName("상품 등록할 때")
+    @Nested
+    class Register {
+
+        @DisplayName("상품 이미지와 상품 등록정보가 주어지면 상품 등록에 성공한다.")
+        @Test
+        void givenImagesAndItemData_whenRegisterItem_thenSuccess() throws Exception {
+            // given
+            givenSetUp();
+
+            var request = RestAssured
+                    .given().log().all()
+                    .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtProvider.createAccessToken(1L))
+                    .multiPart("images",
+                            createFakeFile(),
+                            MediaType.IMAGE_PNG_VALUE)
+                    .multiPart("images",
+                            createFakeFile(),
+                            MediaType.IMAGE_PNG_VALUE)
+                    .multiPart("item",
+                            objectMapper.writeValueAsString(FixtureFactory.createItemRegisterRequest()),
+                            MediaType.APPLICATION_JSON_VALUE);
+
+            // when
+            var response = registerItem(request);
+
+            // then
+            assertAll(
+                    () -> assertThat(response.statusCode()).isEqualTo(201),
+                    () -> assertThat(response.jsonPath().getInt("statusCode")).isEqualTo(201)
+            );
+        }
+
+        @DisplayName("상품 이미지가 아예 주어지지 않으면 400 응답코드로 응답한다.")
+        @Test
+        void givenNoImageAndItemData_whenRegisterItem_thenResponse400() throws Exception {
+            // given
+            givenSetUp();
+
+            // when
+            var request = RestAssured
+                    .given().log().all()
+                    .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtProvider.createAccessToken(1L))
+                    .multiPart("item",
+                            objectMapper.writeValueAsString(FixtureFactory.createItemRegisterRequest()),
+                            MediaType.APPLICATION_JSON_VALUE);
+
+            // when
+            var response = registerItem(request);
+
+            // then
+            assertAll(
+                    () -> assertThat(response.statusCode()).isEqualTo(400),
+                    () -> assertThat(response.jsonPath().getInt("statusCode")).isEqualTo(400),
+                    () -> assertThat(response.jsonPath().getString("message")).isNotNull()
+            );
+        }
+
+        private void givenSetUp() {
+            // objectMapper 한글 인코딩을 위한 설정
+            objectMapper.getFactory().configure(JsonWriteFeature.ESCAPE_NON_ASCII.mappedFeature(), true);
+
+            supportRepository.save(Member.builder()
+                    .email("23Yong@secondhand.com")
+                    .loginId("23Yong")
+                    .profileUrl("image-url")
+                    .build());
+            given(s3Uploader.uploadImageFiles(anyList())).willReturn(List.of("url1", "url2"));
+        }
+
+        private ExtractableResponse<Response> registerItem(RequestSpecification request) {
+            return request
+                    .when()
+                    .post("/api/items")
+                    .then().log().all()
+                    .extract();
+        }
+    }
+}

--- a/src/test/java/kr/codesquad/secondhand/application/item/ItemServiceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/application/item/ItemServiceTest.java
@@ -1,0 +1,74 @@
+package kr.codesquad.secondhand.application.item;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.anyList;
+import static org.mockito.BDDMockito.given;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import kr.codesquad.secondhand.SupportRepository;
+import kr.codesquad.secondhand.application.ApplicationTest;
+import kr.codesquad.secondhand.application.image.S3Uploader;
+import kr.codesquad.secondhand.domain.item.Item;
+import kr.codesquad.secondhand.domain.itemimage.ItemImage;
+import kr.codesquad.secondhand.domain.member.Member;
+import kr.codesquad.secondhand.fixture.FixtureFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+@ApplicationTest
+class ItemServiceTest {
+
+    @MockBean
+    private S3Uploader s3Uploader;
+
+    @Autowired
+    private SupportRepository supportRepository;
+
+    @Autowired
+    private ItemService itemService;
+
+    @DisplayName("상품을 등록하면 상품 정보와 상품 이미지가 DB에 성공적으로 저장된다.")
+    @Test
+    void given_whenRegisterItem_thenSuccess() {
+        // given
+        given(s3Uploader.uploadImageFiles(anyList())).willReturn(List.of("url1", "url2", "url3"));
+        supportRepository.save(Member.builder()
+                .email("23Yong@secondhand.com")
+                .loginId("bruni")
+                .profileUrl("profile-url")
+                .build());
+
+        // when
+        itemService.register(createFakeImage(), FixtureFactory.createItemRegisterRequest(), 1L);
+
+        // then
+        Optional<Item> item = supportRepository.findById(Item.class, 1L);
+        List<ItemImage> images = supportRepository.findAll(ItemImage.class);
+
+        assertAll(
+                () -> assertThat(item).isPresent(),
+                () -> assertThat(images).hasSize(3)
+        );
+    }
+
+    private List<MultipartFile> createFakeImage() {
+        List<MultipartFile> mockMultipartFiles = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            mockMultipartFiles.add(new MockMultipartFile(
+                    "test-image",
+                    "test-image.png",
+                    MediaType.IMAGE_PNG_VALUE,
+                    "image-content".getBytes(StandardCharsets.UTF_8)));
+        }
+        return mockMultipartFiles;
+    }
+}

--- a/src/test/java/kr/codesquad/secondhand/fixture/FixtureFactory.java
+++ b/src/test/java/kr/codesquad/secondhand/fixture/FixtureFactory.java
@@ -1,0 +1,18 @@
+package kr.codesquad.secondhand.fixture;
+
+import kr.codesquad.secondhand.presentation.dto.item.ItemRegisterRequest;
+
+public class FixtureFactory {
+
+    public static ItemRegisterRequest createItemRegisterRequest() {
+        return new ItemRegisterRequest(
+                "선풍기",
+                10000,
+                "바람이 시원한 선풍기",
+                "범안 1동",
+                "판매중",
+                1,
+                "가전/잡화"
+        );
+    }
+}


### PR DESCRIPTION
## Issues
- #16 

## What is this PR? 👓
상품 등록기능에 대한 PR입니다.

## Key changes 🔑
- 상품 등록 기능 구현
- 상품 등록시 여러 장의 이미지를 받을 수 있도록 구현
  - 여러 장의 이미지를 등록할 때 saveAll 메서드 대신 `jdbcTemplate`을 이용한 bulk insert
  - `saveAll` 메서드를 제공하지만 INSERT 쿼리가 여러번 날라감
  - https://velog.io/@rainmaker007/spring-batch-jpa-%ED%99%98%EA%B2%BD%EC%97%90%EC%84%9C-ID-%EC%83%9D%EC%84%B1%EC%A0%84%EB%9E%B5%EC%97%90-%EB%94%B0%EB%A5%B8-bulk-insert-%ED%95%98%EB%8A%94%EB%B2%95
- Auditing 기능 구현
  - JPA가 알아서 상품이 INSERT 될 때 등록하도록 제공하는 Auditing 기능 사용
  - `@EnableJpaAuditing`
  - https://hudi.blog/spring-data-jpa-auditing-create-update-date/
- 테스트코드 작성
  - 간편한 통합 테스트를 위해 RestAssured 의존성 추가

## To reviewers 👋
- MySQL을 사용할 때 PK 생성을 DB에 위임하다보니 `saveAll`을 호출하여도 INSRET VALUES(), () 이렇게 날라가지 않고 INSERT VALUES(), INSERT VALUES() 이렇게 쿼리가 날라가게 되어 jdbcTemplate을 사용해 직접 구현했습니다.
- RestAssured를 도입해 테스트코드를 작성했습니다!