### PR TITLE
상품 전체 목록조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,15 @@
+buildscript {
+    ext {
+        queryDslVersion = "5.0.0"
+    }
+}
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '2.7.14'
     id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+    // QueryDSL
+    id 'com.ewerk.gradle.plugins.querydsl' version '1.0.10'
 }
 
 group = 'kr.codesquad'
@@ -25,6 +33,10 @@ dependencies {
     // spring
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    // QueryDSL
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+    annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}"
 
     // lombok
     compileOnly 'org.projectlombok:lombok'
@@ -54,3 +66,21 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+/** QueryDSL start **/
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+sourceSets {
+    main.java.srcDir querydslDir
+}
+configurations {
+    querydsl.extendsFrom compileClasspath
+}
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
+}
+/** QueryDSL end **/

--- a/src/main/java/kr/codesquad/secondhand/application/item/ItemService.java
+++ b/src/main/java/kr/codesquad/secondhand/application/item/ItemService.java
@@ -6,11 +6,16 @@ import kr.codesquad.secondhand.application.image.ImageService;
 import kr.codesquad.secondhand.domain.item.Item;
 import kr.codesquad.secondhand.domain.itemimage.ItemImage;
 import kr.codesquad.secondhand.domain.member.Member;
+import kr.codesquad.secondhand.presentation.dto.CustomSlice;
 import kr.codesquad.secondhand.presentation.dto.item.ItemRegisterRequest;
+import kr.codesquad.secondhand.presentation.dto.item.ItemResponse;
+import kr.codesquad.secondhand.repository.category.CategoryRepository;
 import kr.codesquad.secondhand.repository.item.ItemRepository;
+import kr.codesquad.secondhand.repository.item.querydsl.ItemPaginationRepository;
 import kr.codesquad.secondhand.repository.itemimage.ItemImageRepository;
 import kr.codesquad.secondhand.repository.member.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -24,6 +29,8 @@ public class ItemService {
     private final ItemRepository itemRepository;
     private final ItemImageRepository itemImageRepository;
     private final MemberRepository memberRepository;
+    private final CategoryRepository categoryRepository;
+    private final ItemPaginationRepository itemPaginationRepository;
 
     @Transactional
     public void register(List<MultipartFile> images, ItemRegisterRequest request, Long sellerId) {
@@ -38,5 +45,27 @@ public class ItemService {
                 .map(url -> ItemImage.toEntity(url, savedItem))
                 .collect(Collectors.toList());
         itemImageRepository.saveAllItemImages(itemImages);
+    }
+
+    public CustomSlice<ItemResponse> readAll(Long itemId, Long categoryId, int pageSize) {
+        String categoryName = null;
+        if (categoryId != null) {
+            categoryName = categoryRepository.findNameById(categoryId).orElse(null);
+        }
+
+        Slice<ItemResponse> response = itemPaginationRepository.findByIdAndCategoryName(itemId, categoryName, pageSize);
+        List<ItemResponse> content = response.getContent();
+
+        Long nextCursor = setNextCursor(content);
+
+        return new CustomSlice<>(content, nextCursor, response.hasNext());
+    }
+
+    private Long setNextCursor(List<ItemResponse> content) {
+        Long nextCursor = null;
+        if (!content.isEmpty()) {
+            nextCursor = content.get(content.size() - 1).getItemId();
+        }
+        return nextCursor;
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/config/QueryDslConfig.java
+++ b/src/main/java/kr/codesquad/secondhand/config/QueryDslConfig.java
@@ -1,0 +1,15 @@
+package kr.codesquad.secondhand.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import javax.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/kr/codesquad/secondhand/domain/item/ItemStatus.java
+++ b/src/main/java/kr/codesquad/secondhand/domain/item/ItemStatus.java
@@ -1,5 +1,6 @@
 package kr.codesquad.secondhand.domain.item;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Arrays;
 import kr.codesquad.secondhand.exception.BadRequestException;
 import kr.codesquad.secondhand.exception.ErrorCode;
@@ -12,6 +13,7 @@ public enum ItemStatus {
 
     ON_SALE("판매중"), SOLD_OUT("판매완료"), RESERVED("예약중");
 
+    @JsonValue
     private final String status;
 
     public static ItemStatus of(String statusName) {

--- a/src/main/java/kr/codesquad/secondhand/presentation/ItemController.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/ItemController.java
@@ -7,14 +7,18 @@ import kr.codesquad.secondhand.application.item.ItemService;
 import kr.codesquad.secondhand.exception.BadRequestException;
 import kr.codesquad.secondhand.exception.ErrorCode;
 import kr.codesquad.secondhand.presentation.dto.ApiResponse;
+import kr.codesquad.secondhand.presentation.dto.CustomSlice;
 import kr.codesquad.secondhand.presentation.dto.item.ItemRegisterRequest;
+import kr.codesquad.secondhand.presentation.dto.item.ItemResponse;
 import kr.codesquad.secondhand.presentation.support.Auth;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -40,5 +44,14 @@ public class ItemController {
                 memberId);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(new ApiResponse<>(HttpStatus.CREATED.value()));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<CustomSlice<ItemResponse>>> readAll(
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(required = false) Long categoryId,
+            @RequestParam(required = false, defaultValue = "10") int size) {
+        return ResponseEntity.ok()
+                .body(new ApiResponse<>(HttpStatus.OK.value(), itemService.readAll(cursor, categoryId, size)));
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/presentation/dto/CustomSlice.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/dto/CustomSlice.java
@@ -1,0 +1,25 @@
+package kr.codesquad.secondhand.presentation.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+public class CustomSlice<T> {
+
+    private final List<T> contents;
+    private final Paging paging;
+
+    public CustomSlice(List<T> contents, Long nextCursor, boolean hasNext) {
+        this.contents = contents;
+        this.paging = new Paging(nextCursor, hasNext);
+    }
+
+    @AllArgsConstructor
+    @Getter
+    public static class Paging {
+
+        private final Long nextCursor;
+        private final boolean hasNext;
+    }
+}

--- a/src/main/java/kr/codesquad/secondhand/presentation/dto/item/ItemResponse.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/dto/item/ItemResponse.java
@@ -1,0 +1,19 @@
+package kr.codesquad.secondhand.presentation.dto.item;
+
+import java.time.LocalDateTime;
+import kr.codesquad.secondhand.domain.item.ItemStatus;
+import lombok.Getter;
+
+@Getter
+public class ItemResponse {
+
+    private Long itemId;
+    private String thumbnailUrl;
+    private String title;
+    private String tradingRegion;
+    private LocalDateTime createdAt;
+    private Integer price;
+    private ItemStatus status;
+    private int chatCount;
+    private int wishCount;
+}

--- a/src/main/java/kr/codesquad/secondhand/repository/category/CategoryRepository.java
+++ b/src/main/java/kr/codesquad/secondhand/repository/category/CategoryRepository.java
@@ -1,7 +1,13 @@
 package kr.codesquad.secondhand.repository.category;
 
+import java.util.Optional;
 import kr.codesquad.secondhand.domain.category.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    @Query("SELECT category.name FROM Category category WHERE category.id = :id")
+    Optional<String> findNameById(@Param("id") Long id);
 }

--- a/src/main/java/kr/codesquad/secondhand/repository/item/querydsl/ItemPaginationRepository.java
+++ b/src/main/java/kr/codesquad/secondhand/repository/item/querydsl/ItemPaginationRepository.java
@@ -1,0 +1,72 @@
+package kr.codesquad.secondhand.repository.item.querydsl;
+
+import static kr.codesquad.secondhand.domain.item.QItem.item;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import kr.codesquad.secondhand.presentation.dto.item.ItemResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class ItemPaginationRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public Slice<ItemResponse> findByIdAndCategoryName(Long itemId, String categoryName, int pageSize) {
+        List<ItemResponse> itemResponses = queryFactory
+                .select(Projections.fields(ItemResponse.class,
+                        item.id.as("itemId"),
+                        item.thumbnailUrl,
+                        item.title,
+                        item.tradingRegion,
+                        item.createdAt,
+                        item.price,
+                        item.status,
+                        item.chatCount,
+                        item.wishCount))
+                .from(item)
+                .where(lessThanItemId(itemId),
+                        equalCategoryName(categoryName)
+                )
+                .orderBy(item.createdAt.desc())
+                .limit(pageSize + 1)    // 다음 요소가 있는지 확인하기 위해 +1개 만큼 더 가져온다.
+                .fetch();
+        return checkLastPage(pageSize, itemResponses);
+    }
+
+    private BooleanExpression lessThanItemId(Long itemId) {
+        if (itemId == null) {
+            return null;
+        }
+
+        return item.id.lt(itemId);
+    }
+
+    private BooleanExpression equalCategoryName(String categoryName) {
+        if (categoryName == null) {
+            return null;
+        }
+
+        return item.categoryName.eq(categoryName);
+    }
+
+    private Slice<ItemResponse> checkLastPage(int pageSize, List<ItemResponse> results) {
+
+        boolean hasNext = false;
+
+        // 조회한 결과 개수가 요청한 페이지 사이즈보다 다음 페이지 존재, next = true
+        if (results.size() > pageSize) {
+            hasNext = true;
+            results.remove(pageSize);
+        }
+
+        return new SliceImpl<>(results, PageRequest.ofSize(pageSize), hasNext);
+    }
+}

--- a/src/test/java/kr/codesquad/secondhand/application/item/ItemServiceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/application/item/ItemServiceTest.java
@@ -12,10 +12,13 @@ import java.util.Optional;
 import kr.codesquad.secondhand.SupportRepository;
 import kr.codesquad.secondhand.application.ApplicationTest;
 import kr.codesquad.secondhand.application.image.S3Uploader;
+import kr.codesquad.secondhand.domain.category.Category;
 import kr.codesquad.secondhand.domain.item.Item;
 import kr.codesquad.secondhand.domain.itemimage.ItemImage;
 import kr.codesquad.secondhand.domain.member.Member;
 import kr.codesquad.secondhand.fixture.FixtureFactory;
+import kr.codesquad.secondhand.presentation.dto.CustomSlice;
+import kr.codesquad.secondhand.presentation.dto.item.ItemResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,11 +44,7 @@ class ItemServiceTest {
     void given_whenRegisterItem_thenSuccess() {
         // given
         given(s3Uploader.uploadImageFiles(anyList())).willReturn(List.of("url1", "url2", "url3"));
-        supportRepository.save(Member.builder()
-                .email("23Yong@secondhand.com")
-                .loginId("bruni")
-                .profileUrl("profile-url")
-                .build());
+        signup();
 
         // when
         itemService.register(createFakeImage(), FixtureFactory.createItemRegisterRequest(), 1L);
@@ -60,6 +59,76 @@ class ItemServiceTest {
         );
     }
 
+    @DisplayName("상품 목록을 조회할 때 첫 페이지에서 최근 등록된 상품 순으로 보여진다.")
+    @Test
+    void givenSavedItemData_whenReadAllItemsOfFirstPage_thenSuccess() {
+        // given
+        for (int i = 1; i <= 30; i++) {
+            supportRepository.save(FixtureFactory.createItem("선풍기 - " + i, "가전", signup()));
+        }
+
+        // when
+        CustomSlice<ItemResponse> response = itemService.readAll(null, null, 10);
+
+        // then
+        assertAll(
+                () -> assertThat(response.getPaging().isHasNext()).isTrue(),
+                () -> assertThat(response.getPaging().getNextCursor()).isEqualTo(21),
+                () -> assertThat(response.getContents().get(0).getTitle()).isEqualTo("선풍기 - 30"),
+                () -> assertThat(response.getContents().get(9).getTitle()).isEqualTo("선풍기 - 21")
+        );
+    }
+
+    @DisplayName("상품 목록을 조회할 때 두 번째 페이지에서 최근 등록된 상품 순으로 보여진다.")
+    @Test
+    void givenSavedItemData_whenReadAllItemsOfSecondPage_thenSuccess() {
+        // given
+        for (int i = 1; i <= 20; i++) {
+            supportRepository.save(FixtureFactory.createItem("선풍기 - " + i, "가전", signup()));
+        }
+
+        // when
+        CustomSlice<ItemResponse> response = itemService.readAll(11L, null, 10);
+
+        // then
+        assertAll(
+                () -> assertThat(response.getPaging().isHasNext()).isFalse(),
+                () -> assertThat(response.getPaging().getNextCursor()).isEqualTo(1),
+                () -> assertThat(response.getContents().get(0).getTitle()).isEqualTo("선풍기 - 10"),
+                () -> assertThat(response.getContents().get(9).getTitle()).isEqualTo("선풍기 - 1")
+        );
+    }
+
+    @DisplayName("카테고리 별 아이템 목록을 조회할 때 첫 페이지에서 해당 카테고리의 최근 등록된 상품 순으로 보여진다.")
+    @Test
+    void givenSavedItemDataAndCategoryId_whenReadAllItemsOfFirstPage_thenSuccess() {
+        // given
+        Member member = signup();
+        supportRepository.save(Category.builder().name("가전").imageUrl("url").build());
+        supportRepository.save(Category.builder().name("식품").imageUrl("url").build());
+
+        for (int i = 1; i <= 10; i++) {
+            supportRepository.save(FixtureFactory.createItem("선풍기 - " + i, "가전", member));
+        }
+        for (int i = 1; i <= 5; i++) {
+            supportRepository.save(FixtureFactory.createItem("맛있는 거 - " + i, "식품", member));
+        }
+        for (int i = 1; i <= 5; i++) {
+            supportRepository.save(FixtureFactory.createItem("맛없는 거 - " + i, "식품", member));
+        }
+
+        // when
+        CustomSlice<ItemResponse> response = itemService.readAll(null, 2L, 8);
+
+        // then
+        assertAll(
+                () -> assertThat(response.getPaging().isHasNext()).isTrue(),
+                () -> assertThat(response.getPaging().getNextCursor()).isEqualTo(13),
+                () -> assertThat(response.getContents().get(0).getTitle()).isEqualTo("맛없는 거 - 5"),
+                () -> assertThat(response.getContents().get(7).getTitle()).isEqualTo("맛있는 거 - 3")
+        );
+    }
+
     private List<MultipartFile> createFakeImage() {
         List<MultipartFile> mockMultipartFiles = new ArrayList<>();
         for (int i = 0; i < 3; i++) {
@@ -70,5 +139,9 @@ class ItemServiceTest {
                     "image-content".getBytes(StandardCharsets.UTF_8)));
         }
         return mockMultipartFiles;
+    }
+
+    private Member signup() {
+        return supportRepository.save(FixtureFactory.createMember());
     }
 }

--- a/src/test/java/kr/codesquad/secondhand/fixture/FixtureFactory.java
+++ b/src/test/java/kr/codesquad/secondhand/fixture/FixtureFactory.java
@@ -1,5 +1,8 @@
 package kr.codesquad.secondhand.fixture;
 
+import kr.codesquad.secondhand.domain.item.Item;
+import kr.codesquad.secondhand.domain.item.ItemStatus;
+import kr.codesquad.secondhand.domain.member.Member;
 import kr.codesquad.secondhand.presentation.dto.item.ItemRegisterRequest;
 
 public class FixtureFactory {
@@ -14,5 +17,25 @@ public class FixtureFactory {
                 1,
                 "가전/잡화"
         );
+    }
+
+    public static Item createItem(String title, String categoryName, Member member) {
+        return Item.builder()
+                .title(title)
+                .status(ItemStatus.ON_SALE)
+                .price(10000)
+                .categoryName(categoryName)
+                .member(member)
+                .thumbnailUrl("url")
+                .tradingRegion("범박동")
+                .build();
+    }
+
+    public static Member createMember() {
+        return Member.builder()
+                .email("23Yong@secondhand.com")
+                .loginId("23Yong")
+                .profileUrl("image-url")
+                .build();
     }
 }


### PR DESCRIPTION
## Issues
- #23 

## What is this PR? 👓
상품 전체 목록 조회에 대한 PR입니다.

## Key changes 🔑
- QueryDSL 의존성 추가
  - 카테고리 아이디가 쿼리파라미터로 주어져도  하나의 메서드로 처리하고 싶어 QueryDSL을 사용해 동적 쿼리를 생성했습니다.
- 상품 전체 목록 조회 / 카테고리별 상품 전체 목록 조회 (with. 페이징)
  - Spring Data JPA에서 제공해주는 Slice를 사용하려 했으나 해당 쿼리는 OFFSET 방식으로 쿼리가 날라가는 것을 확인했습니다.
    - 따라서 QueryDSL을 사용해 NO-OFFSET 방식으로 페이징을 수행했습니다.
- 테스트코드 작성

## To reviewers 👋
- QueryDSL 을 적용해 동적 쿼리를 생성해 보았습니다.
  - 저도 익숙하지 않아서 틀린 부분이 있을 수 있어요..ㅠ
- 상품 전체 목록 조회는 생성일 순으로 내림차순 정렬되게 했습니다..!
