### PR TITLE
상품 상세페이지 조회

### DIFF
--- a/src/main/java/kr/codesquad/secondhand/application/item/ItemService.java
+++ b/src/main/java/kr/codesquad/secondhand/application/item/ItemService.java
@@ -47,7 +47,7 @@ public class ItemService {
     @Transactional
     public ItemDetailResponse read(Long memberId, Long itemId) {
         Item item = itemRepository.findById(itemId)
-                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND));
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND, "상품을 찾을 수 없습니다."));
 
         List<ItemImage> images = itemImageRepository.findByItemId(itemId);
 

--- a/src/main/java/kr/codesquad/secondhand/application/item/ItemService.java
+++ b/src/main/java/kr/codesquad/secondhand/application/item/ItemService.java
@@ -8,6 +8,7 @@ import kr.codesquad.secondhand.domain.itemimage.ItemImage;
 import kr.codesquad.secondhand.domain.member.Member;
 import kr.codesquad.secondhand.exception.BadRequestException;
 import kr.codesquad.secondhand.exception.ErrorCode;
+import kr.codesquad.secondhand.exception.NotFoundException;
 import kr.codesquad.secondhand.presentation.dto.item.ItemDetailResponse;
 import kr.codesquad.secondhand.presentation.dto.item.ItemRegisterRequest;
 import kr.codesquad.secondhand.repository.item.ItemRepository;
@@ -46,12 +47,12 @@ public class ItemService {
     @Transactional
     public ItemDetailResponse read(Long memberId, Long itemId) {
         Item item = itemRepository.findById(itemId)
-                .orElseThrow(() -> new BadRequestException(ErrorCode.INVALID_REQUEST));
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND));
 
         List<ItemImage> images = itemImageRepository.findByItemId(itemId);
 
-        if (memberId != item.getMember().getId()) {
-            itemRepository.incrementViewCount(itemId);
+        if (!item.isSeller(memberId)) {
+            item.incrementViewCount();
             return ItemDetailResponse.toBuyerResponse(item, images);
         }
         return ItemDetailResponse.toSellerResponse(item, images);

--- a/src/main/java/kr/codesquad/secondhand/domain/item/Item.java
+++ b/src/main/java/kr/codesquad/secondhand/domain/item/Item.java
@@ -95,4 +95,12 @@ public class Item extends AuditingFields {
                 .member(member)
                 .build();
     }
+
+    public void incrementViewCount() {
+        this.viewCount += 1;
+    }
+
+    public boolean isSeller(Long memberId) {
+        return this.member.getId() == memberId;
+    }
 }

--- a/src/main/java/kr/codesquad/secondhand/domain/residence/Residence.java
+++ b/src/main/java/kr/codesquad/secondhand/domain/residence/Residence.java
@@ -30,11 +30,11 @@ public class Residence {
     private String addrName;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
     @Builder
-    public Residence(Long id, String addrName, Member member) {
+    private Residence(Long id, String addrName, Member member) {
         this.id = id;
         this.addrName = addrName;
         this.member = member;

--- a/src/main/java/kr/codesquad/secondhand/exception/ErrorCode.java
+++ b/src/main/java/kr/codesquad/secondhand/exception/ErrorCode.java
@@ -24,7 +24,8 @@ public enum ErrorCode {
 
     // COMMON
     INVALID_PARAMETER("유효한 파라미터값이 아닙니다."),
-    INVALID_REQUEST("유효한 요청이 아닙니다.");
+    INVALID_REQUEST("유효한 요청이 아닙니다."),
+    NOT_FOUND("페이지를 찾을 수 없습니다.");
 
     private final String message;
 }

--- a/src/main/java/kr/codesquad/secondhand/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/codesquad/secondhand/exception/GlobalExceptionHandler.java
@@ -31,4 +31,10 @@ public class GlobalExceptionHandler {
         return ResponseEntity.internalServerError()
                 .body(new ErrorResponse(500, e.getMessage()));
     }
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(new ErrorResponse(404, e.getMessage()));
+    }
 }

--- a/src/main/java/kr/codesquad/secondhand/exception/NotFoundException.java
+++ b/src/main/java/kr/codesquad/secondhand/exception/NotFoundException.java
@@ -5,4 +5,8 @@ public class NotFoundException extends SecondHandException {
     public NotFoundException(ErrorCode errorCode) {
         super(errorCode);
     }
+
+    public NotFoundException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
 }

--- a/src/main/java/kr/codesquad/secondhand/exception/NotFoundException.java
+++ b/src/main/java/kr/codesquad/secondhand/exception/NotFoundException.java
@@ -1,0 +1,8 @@
+package kr.codesquad.secondhand.exception;
+
+public class NotFoundException extends SecondHandException {
+
+    public NotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/kr/codesquad/secondhand/presentation/ItemController.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/ItemController.java
@@ -7,12 +7,15 @@ import kr.codesquad.secondhand.application.item.ItemService;
 import kr.codesquad.secondhand.exception.BadRequestException;
 import kr.codesquad.secondhand.exception.ErrorCode;
 import kr.codesquad.secondhand.presentation.dto.ApiResponse;
+import kr.codesquad.secondhand.presentation.dto.item.ItemDetailResponse;
 import kr.codesquad.secondhand.presentation.dto.item.ItemRegisterRequest;
 import kr.codesquad.secondhand.presentation.support.Auth;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -40,5 +43,15 @@ public class ItemController {
                 memberId);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(new ApiResponse<>(HttpStatus.CREATED.value()));
+    }
+
+    @GetMapping("/{itemId}")
+    public ResponseEntity<ApiResponse<ItemDetailResponse>> readItem(@PathVariable Long itemId,
+                                                                    @Auth Long memberId) {
+        return ResponseEntity.ok()
+                .body(new ApiResponse<>(
+                        HttpStatus.OK.value(),
+                        itemService.read(memberId, itemId))
+                );
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/presentation/dto/item/ItemDetailResponse.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/dto/item/ItemDetailResponse.java
@@ -29,9 +29,8 @@ public class ItemDetailResponse {
 
     @Builder
     private ItemDetailResponse(boolean isSeller, List<String> imageUrls, String seller, String status, String title,
-                               String categoryName, LocalDateTime createdAt, String content, int chatCount,
-                               int wishCount,
-                               int viewCount, int price) {
+                               String categoryName, LocalDateTime createdAt, String content,
+                               int chatCount, int wishCount, int viewCount, int price) {
         this.isSeller = isSeller;
         this.imageUrls = imageUrls;
         this.seller = seller;
@@ -49,7 +48,9 @@ public class ItemDetailResponse {
     public static ItemDetailResponse toSellerResponse(Item item, List<ItemImage> images) {
         return ItemDetailResponse.builder()
                 .isSeller(true)
-                .imageUrls(images.stream().map(ItemImage::getImageUrl).collect(Collectors.toUnmodifiableList()))
+                .imageUrls(images.stream()
+                        .map(ItemImage::getImageUrl)
+                        .collect(Collectors.toUnmodifiableList()))
                 .seller(item.getMember().getLoginId())
                 .status(item.getStatus().getStatus())
                 .title(item.getTitle())
@@ -66,7 +67,9 @@ public class ItemDetailResponse {
     public static ItemDetailResponse toBuyerResponse(Item item, List<ItemImage> images) {
         return ItemDetailResponse.builder()
                 .isSeller(false)
-                .imageUrls(images.stream().map(ItemImage::getImageUrl).collect(Collectors.toUnmodifiableList()))
+                .imageUrls(images.stream()
+                        .map(ItemImage::getImageUrl)
+                        .collect(Collectors.toUnmodifiableList()))
                 .seller(item.getMember().getLoginId())
                 .title(item.getTitle())
                 .categoryName(item.getCategoryName())

--- a/src/main/java/kr/codesquad/secondhand/presentation/dto/item/ItemDetailResponse.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/dto/item/ItemDetailResponse.java
@@ -1,0 +1,81 @@
+package kr.codesquad.secondhand.presentation.dto.item;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import kr.codesquad.secondhand.domain.item.Item;
+import kr.codesquad.secondhand.domain.itemimage.ItemImage;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ItemDetailResponse {
+
+    private final boolean isSeller;
+    private final List<String> imageUrls;
+    private final String seller;
+    @JsonInclude(Include.NON_NULL)
+    private final String status;
+    private final String title;
+    private final String categoryName;
+    private final LocalDateTime createdAt;
+    private final String content;
+    private final int chatCount;
+    private final int wishCount;
+    private final int viewCount;
+    private final int price;
+
+    @Builder
+    private ItemDetailResponse(boolean isSeller, List<String> imageUrls, String seller, String status, String title,
+                               String categoryName, LocalDateTime createdAt, String content, int chatCount,
+                               int wishCount,
+                               int viewCount, int price) {
+        this.isSeller = isSeller;
+        this.imageUrls = imageUrls;
+        this.seller = seller;
+        this.status = status;
+        this.title = title;
+        this.categoryName = categoryName;
+        this.createdAt = createdAt;
+        this.content = content;
+        this.chatCount = chatCount;
+        this.wishCount = wishCount;
+        this.viewCount = viewCount;
+        this.price = price;
+    }
+
+    public static ItemDetailResponse toSellerResponse(Item item, List<ItemImage> images) {
+        return ItemDetailResponse.builder()
+                .isSeller(true)
+                .imageUrls(images.stream().map(ItemImage::getImageUrl).collect(Collectors.toUnmodifiableList()))
+                .seller(item.getMember().getLoginId())
+                .status(item.getStatus().getStatus())
+                .title(item.getTitle())
+                .categoryName(item.getCategoryName())
+                .createdAt(item.getCreatedAt())
+                .content(item.getContent())
+                .chatCount(item.getChatCount())
+                .wishCount(item.getWishCount())
+                .viewCount(item.getViewCount())
+                .price(item.getPrice())
+                .build();
+    }
+
+    public static ItemDetailResponse toBuyerResponse(Item item, List<ItemImage> images) {
+        return ItemDetailResponse.builder()
+                .isSeller(false)
+                .imageUrls(images.stream().map(ItemImage::getImageUrl).collect(Collectors.toUnmodifiableList()))
+                .seller(item.getMember().getLoginId())
+                .title(item.getTitle())
+                .categoryName(item.getCategoryName())
+                .createdAt(item.getCreatedAt())
+                .content(item.getContent())
+                .chatCount(item.getChatCount())
+                .wishCount(item.getWishCount())
+                .viewCount(item.getViewCount() + 1)
+                .price(item.getPrice())
+                .build();
+    }
+}

--- a/src/main/java/kr/codesquad/secondhand/repository/item/ItemRepository.java
+++ b/src/main/java/kr/codesquad/secondhand/repository/item/ItemRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface ItemRepository extends JpaRepository<Item, Long> {
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("UPDATE Item i SET i.viewCount = i.viewCount + 1 WHERE i.id = :itemId")
     void incrementViewCount(Long itemId);
 }

--- a/src/main/java/kr/codesquad/secondhand/repository/item/ItemRepository.java
+++ b/src/main/java/kr/codesquad/secondhand/repository/item/ItemRepository.java
@@ -6,8 +6,4 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface ItemRepository extends JpaRepository<Item, Long> {
-
-    @Modifying(clearAutomatically = true)
-    @Query("UPDATE Item i SET i.viewCount = i.viewCount + 1 WHERE i.id = :itemId")
-    void incrementViewCount(Long itemId);
 }

--- a/src/main/java/kr/codesquad/secondhand/repository/item/ItemRepository.java
+++ b/src/main/java/kr/codesquad/secondhand/repository/item/ItemRepository.java
@@ -2,6 +2,12 @@ package kr.codesquad.secondhand.repository.item;
 
 import kr.codesquad.secondhand.domain.item.Item;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ItemRepository extends JpaRepository<Item, Long> {
+
+    @Modifying
+    @Query("UPDATE Item i SET i.viewCount = i.viewCount + 1 WHERE i.id = :itemId")
+    void incrementViewCount(Long itemId);
 }

--- a/src/main/java/kr/codesquad/secondhand/repository/itemimage/ItemImageRepository.java
+++ b/src/main/java/kr/codesquad/secondhand/repository/itemimage/ItemImageRepository.java
@@ -1,7 +1,10 @@
 package kr.codesquad.secondhand.repository.itemimage;
 
+import java.util.List;
 import kr.codesquad.secondhand.domain.itemimage.ItemImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ItemImageRepository extends JpaRepository<ItemImage, Long>, ItemImageRepositoryCustom {
+
+    List<ItemImage> findByItemId(Long itemId);
 }


### PR DESCRIPTION
## Issues
- #25 

## What is this PR? 👓
상품 상세페이지 조회 기능을 구현한 PR입니다.

## Key changes 🔑
- 판매자의 상품 상세페이지
  - 상품의 상태를 포함
- 구매자의 상품 상세페이지
  - 조회수 1 증가

## To reviewers 👋
- 구매자가 조회하는 경우 흐름이 db에서 `Item` 찾기 -> 구매자라면 db에 `view_count` 1 증가시키기 -> response의 `viewCount`에 +1 인데, response 에서 임의로 조회수 +1 해주는게 나은지 아니면 다시 db에서 꺼내오는게 좋을지 모르겠어요! 어떻게 생각하시나요? 🥹