### PR TITLE
토큰 관련 로직 수정 + 테스트코드

### DIFF
--- a/src/main/java/kr/codesquad/secondhand/application/auth/AuthService.java
+++ b/src/main/java/kr/codesquad/secondhand/application/auth/AuthService.java
@@ -3,17 +3,17 @@ package kr.codesquad.secondhand.application.auth;
 import java.util.Optional;
 import kr.codesquad.secondhand.application.image.ImageService;
 import kr.codesquad.secondhand.domain.member.Member;
+import kr.codesquad.secondhand.domain.member.UserProfile;
 import kr.codesquad.secondhand.domain.residence.Residence;
 import kr.codesquad.secondhand.domain.token.RefreshToken;
 import kr.codesquad.secondhand.exception.DuplicatedException;
 import kr.codesquad.secondhand.exception.ErrorCode;
 import kr.codesquad.secondhand.exception.UnAuthorizedException;
 import kr.codesquad.secondhand.infrastructure.jwt.JwtProvider;
+import kr.codesquad.secondhand.presentation.dto.OauthTokenResponse;
 import kr.codesquad.secondhand.presentation.dto.member.LoginRequest;
 import kr.codesquad.secondhand.presentation.dto.member.LoginResponse;
-import kr.codesquad.secondhand.presentation.dto.OauthTokenResponse;
 import kr.codesquad.secondhand.presentation.dto.member.SignUpRequest;
-import kr.codesquad.secondhand.domain.member.UserProfile;
 import kr.codesquad.secondhand.presentation.dto.member.UserResponse;
 import kr.codesquad.secondhand.presentation.dto.token.AuthToken;
 import kr.codesquad.secondhand.repository.member.MemberRepository;
@@ -43,6 +43,8 @@ public class AuthService {
         Long memberId = verifyUser(request, userProfile);
 
         String refreshToken = jwtProvider.createRefreshToken(memberId);
+        tokenRepository.deleteByMemberId(memberId);
+
         tokenRepository.save(RefreshToken.builder()
                 .memberId(memberId)
                 .token(refreshToken)

--- a/src/main/java/kr/codesquad/secondhand/application/item/ItemService.java
+++ b/src/main/java/kr/codesquad/secondhand/application/item/ItemService.java
@@ -6,10 +6,9 @@ import kr.codesquad.secondhand.application.image.ImageService;
 import kr.codesquad.secondhand.domain.item.Item;
 import kr.codesquad.secondhand.domain.itemimage.ItemImage;
 import kr.codesquad.secondhand.domain.member.Member;
-import kr.codesquad.secondhand.presentation.dto.CustomSlice;
-import kr.codesquad.secondhand.exception.BadRequestException;
 import kr.codesquad.secondhand.exception.ErrorCode;
 import kr.codesquad.secondhand.exception.NotFoundException;
+import kr.codesquad.secondhand.presentation.dto.CustomSlice;
 import kr.codesquad.secondhand.presentation.dto.item.ItemDetailResponse;
 import kr.codesquad.secondhand.presentation.dto.item.ItemRegisterRequest;
 import kr.codesquad.secondhand.presentation.dto.item.ItemResponse;
@@ -60,14 +59,14 @@ public class ItemService {
         Slice<ItemResponse> response = itemPaginationRepository.findByIdAndCategoryName(itemId, categoryName, pageSize);
         List<ItemResponse> content = response.getContent();
 
-        Long nextCursor = setNextCursor(content);
+        Long nextCursor = setNextCursor(content, pageSize);
 
         return new CustomSlice<>(content, nextCursor, response.hasNext());
     }
 
-    private Long setNextCursor(List<ItemResponse> content) {
+    private Long setNextCursor(List<ItemResponse> content, int pageSize) {
         Long nextCursor = null;
-        if (!content.isEmpty()) {
+        if (content.size() == pageSize) {
             nextCursor = content.get(content.size() - 1).getItemId();
         }
         return nextCursor;

--- a/src/main/java/kr/codesquad/secondhand/domain/token/RefreshToken.java
+++ b/src/main/java/kr/codesquad/secondhand/domain/token/RefreshToken.java
@@ -1,14 +1,15 @@
 package kr.codesquad.secondhand.domain.token;
 
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
-
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "refresh_token")
 @Entity

--- a/src/main/java/kr/codesquad/secondhand/presentation/AuthController.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/AuthController.java
@@ -14,6 +14,7 @@ import kr.codesquad.secondhand.presentation.dto.token.AccessTokenResponse;
 import kr.codesquad.secondhand.presentation.dto.token.TokenRenewRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -45,8 +46,11 @@ public class AuthController {
                 ));
     }
 
-    @PostMapping("/naver/signup")
-    public ResponseEntity<ApiResponse<Void>> signUp(@RequestBody @Valid SignUpRequest request,
+    @PostMapping(value = "/naver/signup", consumes = {
+            MediaType.MULTIPART_FORM_DATA_VALUE,
+            MediaType.APPLICATION_JSON_VALUE
+    })
+    public ResponseEntity<ApiResponse<Void>> signUp(@RequestPart @Valid SignUpRequest request,
                                                     @RequestParam Optional<String> code,
                                                     @RequestParam Optional<String> state,
                                                     @RequestPart Optional<MultipartFile> profile) {

--- a/src/main/java/kr/codesquad/secondhand/presentation/dto/item/ItemDetailResponse.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/dto/item/ItemDetailResponse.java
@@ -77,7 +77,7 @@ public class ItemDetailResponse {
                 .content(item.getContent())
                 .chatCount(item.getChatCount())
                 .wishCount(item.getWishCount())
-                .viewCount(item.getViewCount() + 1)
+                .viewCount(item.getViewCount())
                 .price(item.getPrice())
                 .build();
     }

--- a/src/main/java/kr/codesquad/secondhand/repository/token/TokenRepository.java
+++ b/src/main/java/kr/codesquad/secondhand/repository/token/TokenRepository.java
@@ -2,6 +2,13 @@ package kr.codesquad.secondhand.repository.token;
 
 import kr.codesquad.secondhand.domain.token.RefreshToken;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM RefreshToken refreshToken WHERE refreshToken.memberId = :memberId")
+    void deleteByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/test/java/kr/codesquad/secondhand/acceptance/AcceptanceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/acceptance/AcceptanceTest.java
@@ -1,0 +1,17 @@
+package kr.codesquad.secondhand.acceptance;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import kr.codesquad.secondhand.DatabaseInitializerExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@ExtendWith(DatabaseInitializerExtension.class)
+@SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
+public @interface AcceptanceTest {
+}

--- a/src/test/java/kr/codesquad/secondhand/acceptance/AcceptanceTestSupport.java
+++ b/src/test/java/kr/codesquad/secondhand/acceptance/AcceptanceTestSupport.java
@@ -1,0 +1,30 @@
+package kr.codesquad.secondhand.acceptance;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.codesquad.secondhand.SupportRepository;
+import kr.codesquad.secondhand.application.auth.NaverRequester;
+import kr.codesquad.secondhand.application.image.S3Uploader;
+import kr.codesquad.secondhand.domain.member.Member;
+import kr.codesquad.secondhand.fixture.FixtureFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@AcceptanceTest
+public abstract class AcceptanceTestSupport {
+
+    @MockBean
+    protected S3Uploader s3Uploader;
+
+    @MockBean
+    protected NaverRequester naverRequester;
+
+    @Autowired
+    protected SupportRepository supportRepository;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    protected Member signup() {
+        return supportRepository.save(FixtureFactory.createMember());
+    }
+}

--- a/src/test/java/kr/codesquad/secondhand/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/acceptance/AuthAcceptanceTest.java
@@ -7,7 +7,13 @@ import static org.mockito.BDDMockito.anyString;
 import static org.mockito.BDDMockito.given;
 
 import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+import java.io.File;
+import java.io.IOException;
 import java.util.Map;
+import kr.codesquad.secondhand.domain.image.ImageFile;
 import kr.codesquad.secondhand.domain.member.UserProfile;
 import kr.codesquad.secondhand.presentation.dto.OauthTokenResponse;
 import org.junit.jupiter.api.DisplayName;
@@ -17,6 +23,17 @@ import org.springframework.http.MediaType;
 
 public class AuthAcceptanceTest extends AcceptanceTestSupport {
 
+    private void mockingOAuth() {
+        given(naverRequester.getToken(anyString()))
+                .willReturn(new OauthTokenResponse("accessToken", "email", "bearer"));
+        given(naverRequester.getUserProfile(any(OauthTokenResponse.class)))
+                .willReturn(new UserProfile("23Yong@secondhand.com", "profileUrl"));
+    }
+
+    private File createFakeFile() throws IOException {
+        return File.createTempFile("test-image", ".png");
+    }
+
     @DisplayName("로그인할 때")
     @Nested
     class Login {
@@ -25,10 +42,7 @@ public class AuthAcceptanceTest extends AcceptanceTestSupport {
         @Test
         void givenLoginData_whenLogin_thenSuccess() {
             // given
-            given(naverRequester.getToken(anyString()))
-                    .willReturn(new OauthTokenResponse("accessToken", "email", "bearer"));
-            given(naverRequester.getUserProfile(any(OauthTokenResponse.class)))
-                    .willReturn(new UserProfile("23Yong@secondhand.com", "profileUrl"));
+            mockingOAuth();
 
             signup();
 
@@ -40,10 +54,7 @@ public class AuthAcceptanceTest extends AcceptanceTestSupport {
                     .body(Map.of("loginId", "23yong"));
 
             // when
-            var response = request
-                    .post("/api/auth/naver/login")
-                    .then().log().all()
-                    .extract();
+            var response = login(request);
 
             // then
             assertAll(
@@ -57,7 +68,7 @@ public class AuthAcceptanceTest extends AcceptanceTestSupport {
 
         @DisplayName("인가코드가 주어지지 않으면 400 응답이 온다.")
         @Test
-        void givenLoginData_whenLogin_thenResponse400() {
+        void givenNoAuthorizationCode_whenLogin_thenResponse400() {
             // given
             var request = RestAssured
                     .given().log().all()
@@ -66,10 +77,7 @@ public class AuthAcceptanceTest extends AcceptanceTestSupport {
                     .body(Map.of("loginId", "23yong"));
 
             // when
-            var response = request
-                    .post("/api/auth/naver/login")
-                    .then().log().all()
-                    .extract();
+            var response = login(request);
 
             // then
             assertThat(response.statusCode()).isEqualTo(400);
@@ -79,10 +87,7 @@ public class AuthAcceptanceTest extends AcceptanceTestSupport {
         @Test
         void givenInvalidLoginData_whenLogin_thenResponse401() {
             // given
-            given(naverRequester.getToken(anyString()))
-                    .willReturn(new OauthTokenResponse("accessToken", "email", "bearer"));
-            given(naverRequester.getUserProfile(any(OauthTokenResponse.class)))
-                    .willReturn(new UserProfile("23Yong@secondhand.com", "profileUrl"));
+            mockingOAuth();
 
             signup();
 
@@ -94,13 +99,76 @@ public class AuthAcceptanceTest extends AcceptanceTestSupport {
                     .body(Map.of("loginId", "joy"));
 
             // when
-            var response = request
+            var response = login(request);
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(401);
+        }
+
+        private ExtractableResponse<Response> login(RequestSpecification request) {
+            return request
                     .post("/api/auth/naver/login")
+                    .then().log().all()
+                    .extract();
+        }
+    }
+
+    @DisplayName("회원가입할 때")
+    @Nested
+    class Signup {
+
+        @DisplayName("올바른 회원가입 정보가 주어지면 회원가입에 성공한다.")
+        @Test
+        void givenSignupData_whenSignup_thenSuccess() throws IOException {
+            // given
+            mockingOAuth();
+            given(s3Uploader.uploadImageFile(any(ImageFile.class))).willReturn("profileUrl");
+
+            var request = RestAssured
+                    .given().log().all()
+                    .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
+                    .queryParam("code", "code")
+                    .queryParam("state", "state")
+                    .multiPart("request", Map.of("loginId", "bruni", "addrName", "범박동"),
+                            MediaType.APPLICATION_JSON_VALUE)
+                    .multiPart("profile", createFakeFile(),
+                            MediaType.IMAGE_PNG_VALUE);
+
+            // when
+            var response = request
+                    .when()
+                    .post("/api/auth/naver/signup")
                     .then().log().all()
                     .extract();
 
             // then
-            assertThat(response.statusCode()).isEqualTo(401);
+            assertThat(response.statusCode()).isEqualTo(201);
+        }
+
+        @DisplayName("인가코드가 주어지지 않으면 400응답을 한다.")
+        @Test
+        void givenNoAuthorizationCode_whenSignup_thenResponse400() throws IOException {
+            // given
+            var request = RestAssured
+                    .given().log().all()
+                    .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
+                    .queryParam("state", "state")
+                    .multiPart("request",
+                            Map.of("loginId", "bruni", "addrName", "범박동"),
+                            MediaType.APPLICATION_JSON_VALUE)
+                    .multiPart("profile",
+                            createFakeFile(),
+                            MediaType.IMAGE_PNG_VALUE);
+
+            // when
+            var response = request
+                    .when()
+                    .post("/api/auth/naver/signup")
+                    .then().log().all()
+                    .extract();
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(400);
         }
     }
 }

--- a/src/test/java/kr/codesquad/secondhand/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/acceptance/AuthAcceptanceTest.java
@@ -1,0 +1,106 @@
+package kr.codesquad.secondhand.acceptance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.anyString;
+import static org.mockito.BDDMockito.given;
+
+import io.restassured.RestAssured;
+import java.util.Map;
+import kr.codesquad.secondhand.domain.member.UserProfile;
+import kr.codesquad.secondhand.presentation.dto.OauthTokenResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+public class AuthAcceptanceTest extends AcceptanceTestSupport {
+
+    @DisplayName("로그인할 때")
+    @Nested
+    class Login {
+
+        @DisplayName("로그인 정보가 일치하면 로그인에 성공한다.")
+        @Test
+        void givenLoginData_whenLogin_thenSuccess() {
+            // given
+            given(naverRequester.getToken(anyString()))
+                    .willReturn(new OauthTokenResponse("accessToken", "email", "bearer"));
+            given(naverRequester.getUserProfile(any(OauthTokenResponse.class)))
+                    .willReturn(new UserProfile("23Yong@secondhand.com", "profileUrl"));
+
+            signup();
+
+            var request = RestAssured
+                    .given().log().all()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .queryParam("code", "code")
+                    .queryParam("state", "state")
+                    .body(Map.of("loginId", "23yong"));
+
+            // when
+            var response = request
+                    .post("/api/auth/naver/login")
+                    .then().log().all()
+                    .extract();
+
+            // then
+            assertAll(
+                    () -> assertThat(response.statusCode()).isEqualTo(200),
+                    () -> assertThat(response.jsonPath().getString("data.jwt.accessToken")).isNotNull(),
+                    () -> assertThat(response.jsonPath().getString("data.jwt.refreshToken")).isNotNull(),
+                    () -> assertThat(response.jsonPath().getString("data.user.loginId")).isNotNull(),
+                    () -> assertThat(response.jsonPath().getString("data.user.profileUrl")).isNotNull()
+            );
+        }
+
+        @DisplayName("인가코드가 주어지지 않으면 400 응답이 온다.")
+        @Test
+        void givenLoginData_whenLogin_thenResponse400() {
+            // given
+            var request = RestAssured
+                    .given().log().all()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .queryParam("state", "state")
+                    .body(Map.of("loginId", "23yong"));
+
+            // when
+            var response = request
+                    .post("/api/auth/naver/login")
+                    .then().log().all()
+                    .extract();
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(400);
+        }
+
+        @DisplayName("일치하지 않는 로그인 데이터가 주어지면 401 응답이 온다.")
+        @Test
+        void givenInvalidLoginData_whenLogin_thenResponse401() {
+            // given
+            given(naverRequester.getToken(anyString()))
+                    .willReturn(new OauthTokenResponse("accessToken", "email", "bearer"));
+            given(naverRequester.getUserProfile(any(OauthTokenResponse.class)))
+                    .willReturn(new UserProfile("23Yong@secondhand.com", "profileUrl"));
+
+            signup();
+
+            var request = RestAssured
+                    .given().log().all()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .queryParam("code", "code")
+                    .queryParam("state", "state")
+                    .body(Map.of("loginId", "joy"));
+
+            // when
+            var response = request
+                    .post("/api/auth/naver/login")
+                    .then().log().all()
+                    .extract();
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(401);
+        }
+    }
+}

--- a/src/test/java/kr/codesquad/secondhand/acceptance/ItemAcceptanceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/acceptance/ItemAcceptanceTest.java
@@ -6,7 +6,6 @@ import static org.mockito.BDDMockito.anyList;
 import static org.mockito.BDDMockito.given;
 
 import com.fasterxml.jackson.core.json.JsonWriteFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -14,9 +13,6 @@ import io.restassured.specification.RequestSpecification;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
-import kr.codesquad.secondhand.DatabaseInitializerExtension;
-import kr.codesquad.secondhand.SupportRepository;
-import kr.codesquad.secondhand.application.image.S3Uploader;
 import kr.codesquad.secondhand.domain.member.Member;
 import kr.codesquad.secondhand.fixture.FixtureFactory;
 import kr.codesquad.secondhand.infrastructure.jwt.JwtProvider;
@@ -24,35 +20,16 @@ import org.apache.http.HttpHeaders;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 
-@ExtendWith(DatabaseInitializerExtension.class)
-@SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
-public class ItemAcceptanceTest {
-
-    @Autowired
-    private ObjectMapper objectMapper;
+public class ItemAcceptanceTest extends AcceptanceTestSupport {
 
     @Autowired
     private JwtProvider jwtProvider;
 
-    @Autowired
-    private SupportRepository supportRepository;
-
-    @MockBean
-    private S3Uploader s3Uploader;
-
     private File createFakeFile() throws IOException {
         return File.createTempFile("test-image", ".png");
-    }
-
-    private Member signup() {
-        return supportRepository.save(FixtureFactory.createMember());
     }
 
     private void saveItems(Member member) {

--- a/src/test/java/kr/codesquad/secondhand/application/ApplicationTestSupport.java
+++ b/src/test/java/kr/codesquad/secondhand/application/ApplicationTestSupport.java
@@ -1,0 +1,20 @@
+package kr.codesquad.secondhand.application;
+
+import kr.codesquad.secondhand.SupportRepository;
+import kr.codesquad.secondhand.application.auth.NaverRequester;
+import kr.codesquad.secondhand.application.image.S3Uploader;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@ApplicationTest
+public class ApplicationTestSupport {
+
+    @MockBean
+    protected S3Uploader s3Uploader;
+
+    @Autowired
+    protected SupportRepository supportRepository;
+
+    @MockBean
+    protected NaverRequester naverRequester;
+}

--- a/src/test/java/kr/codesquad/secondhand/application/ApplicationTestSupport.java
+++ b/src/test/java/kr/codesquad/secondhand/application/ApplicationTestSupport.java
@@ -7,7 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
 @ApplicationTest
-public class ApplicationTestSupport {
+public abstract class ApplicationTestSupport {
 
     @MockBean
     protected S3Uploader s3Uploader;

--- a/src/test/java/kr/codesquad/secondhand/application/auth/AuthServiceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/application/auth/AuthServiceTest.java
@@ -8,33 +8,26 @@ import static org.mockito.BDDMockito.anyString;
 import static org.mockito.BDDMockito.given;
 
 import java.util.Optional;
-import kr.codesquad.secondhand.SupportRepository;
 import kr.codesquad.secondhand.application.ApplicationTest;
+import kr.codesquad.secondhand.application.ApplicationTestSupport;
 import kr.codesquad.secondhand.domain.member.Member;
+import kr.codesquad.secondhand.domain.member.UserProfile;
 import kr.codesquad.secondhand.domain.token.RefreshToken;
 import kr.codesquad.secondhand.exception.ErrorCode;
 import kr.codesquad.secondhand.exception.UnAuthorizedException;
+import kr.codesquad.secondhand.presentation.dto.OauthTokenResponse;
 import kr.codesquad.secondhand.presentation.dto.member.LoginRequest;
 import kr.codesquad.secondhand.presentation.dto.member.LoginResponse;
-import kr.codesquad.secondhand.presentation.dto.OauthTokenResponse;
-import kr.codesquad.secondhand.domain.member.UserProfile;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
 @ApplicationTest
-class AuthServiceTest {
+class AuthServiceTest extends ApplicationTestSupport {
 
     @Autowired
     private AuthService authService;
-
-    @Autowired
-    private SupportRepository supportRepository;
-
-    @MockBean
-    private NaverRequester naverRequester;
 
     @Nested
     class Login {
@@ -64,6 +57,31 @@ class AuthServiceTest {
                     () -> assertThat(response.getUser().getLoginId()).isNotBlank(),
                     () -> assertThat(response.getUser().getProfileUrl()).isNotBlank()
             );
+        }
+
+        @DisplayName("리프레시 토큰이 존재하는 사용자가 다시 로그인을 시도할 때 존재하는 리프레시 토큰을 삭제하고 새로운 리프레시 토큰을 저장한다.")
+        @Test
+        void givenLoginDataAndAlreadyHasRefreshToken_whenLogin_thenSuccess() {
+            // given
+            mockingOAuthInfo();
+
+            LoginRequest request = new LoginRequest("joy");
+            supportRepository.save(Member.builder()
+                    .email("joy@naver.com")
+                    .loginId("joy")
+                    .profileUrl("url")
+                    .build());
+            supportRepository.save(RefreshToken.builder()
+                    .memberId(1L)
+                    .token("token.token.token")
+                    .build());
+
+            // when
+            authService.login(request, "code");
+
+            // then
+            assertThat(supportRepository.findById(RefreshToken.class, 1L).get().getToken())
+                    .isNotEqualTo("token.token.token");
         }
 
         @DisplayName("아이디는 존재하지만 해당 아이디의 이메일과 Naver 이메일 정보가 일치하지 않는 로그인 정보가 주어지면 예외를 던진다.")

--- a/src/test/java/kr/codesquad/secondhand/application/auth/TokenServiceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/application/auth/TokenServiceTest.java
@@ -1,8 +1,11 @@
 package kr.codesquad.secondhand.application.auth;
 
-import kr.codesquad.secondhand.SupportRepository;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import kr.codesquad.secondhand.TokenCreator;
 import kr.codesquad.secondhand.application.ApplicationTest;
+import kr.codesquad.secondhand.application.ApplicationTestSupport;
 import kr.codesquad.secondhand.domain.token.RefreshToken;
 import kr.codesquad.secondhand.exception.ErrorCode;
 import kr.codesquad.secondhand.exception.UnAuthorizedException;
@@ -12,17 +15,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 @ApplicationTest
-class TokenServiceTest {
+class TokenServiceTest extends ApplicationTestSupport {
 
     @Autowired
     private JwtProvider jwtProvider;
-
-    @Autowired
-    private SupportRepository supportRepository;
 
     @Autowired
     private TokenService tokenService;

--- a/src/test/java/kr/codesquad/secondhand/application/category/CategoryServiceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/application/category/CategoryServiceTest.java
@@ -2,23 +2,19 @@ package kr.codesquad.secondhand.application.category;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import kr.codesquad.secondhand.SupportRepository;
 import kr.codesquad.secondhand.application.ApplicationTest;
+import kr.codesquad.secondhand.application.ApplicationTestSupport;
 import kr.codesquad.secondhand.domain.category.Category;
 import kr.codesquad.secondhand.presentation.dto.category.CategoryListResponse;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @ApplicationTest
-public class CategoryServiceTest {
+public class CategoryServiceTest extends ApplicationTestSupport {
 
     @Autowired
     private CategoryService categoryService;
-
-    @Autowired
-    private SupportRepository supportRepository;
 
     @DisplayName("카테고리 목록을 반환한다.")
     @Test

--- a/src/test/java/kr/codesquad/secondhand/application/item/ItemServiceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/application/item/ItemServiceTest.java
@@ -9,9 +9,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import kr.codesquad.secondhand.SupportRepository;
 import kr.codesquad.secondhand.application.ApplicationTest;
-import kr.codesquad.secondhand.application.image.S3Uploader;
+import kr.codesquad.secondhand.application.ApplicationTestSupport;
 import kr.codesquad.secondhand.domain.category.Category;
 import kr.codesquad.secondhand.domain.item.Item;
 import kr.codesquad.secondhand.domain.item.ItemStatus;
@@ -19,24 +18,17 @@ import kr.codesquad.secondhand.domain.itemimage.ItemImage;
 import kr.codesquad.secondhand.domain.member.Member;
 import kr.codesquad.secondhand.fixture.FixtureFactory;
 import kr.codesquad.secondhand.presentation.dto.CustomSlice;
-import kr.codesquad.secondhand.presentation.dto.item.ItemResponse;
 import kr.codesquad.secondhand.presentation.dto.item.ItemDetailResponse;
+import kr.codesquad.secondhand.presentation.dto.item.ItemResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
 @ApplicationTest
-class ItemServiceTest {
-
-    @MockBean
-    private S3Uploader s3Uploader;
-
-    @Autowired
-    private SupportRepository supportRepository;
+class ItemServiceTest extends ApplicationTestSupport {
 
     @Autowired
     private ItemService itemService;


### PR DESCRIPTION
## Issues
- #28 

## What is this PR? 👓
토큰 관련된 로직을 수정한 PR입니다.

## Key changes 🔑
\+ 추가적으로 인증 관련 부분해서 테스트코드를 작성했습니다.
이때 발견한 오류들을 수정했습니다.
- 회원가입시 이미지가 함께 들어오기 때문에 `Content-Type`이 `multipart/form-data`입니다.
  - 이때 들어오는 JSON 타입에서도 `@RequestBody`가 아닌 `@RequestPart`로 수정해야지 415응답코드를 응답하지 않습니다.
  - 이를 위해 `@PostMapping`의 `consumes` 속성을 이용해 어떤 데이터가 들어오는지 정의했습니다.
  - 다른 방법으로는 `@ModelAttribute`를 이용하는 방법이 있습니다.
  - https://minholee93.tistory.com/entry/Spring-Json-with-MultipartFile
- 페이징시 다음 상품이 존재하지 않으면 `nextCursor`가 `null`이여야 하는데 그렇지 않아 이를 수정했습니다.

## To reviewers 👋
하나만 고치기에는 너무 작아서 테스트코드도 작성했습니다..ㅎㅎ
[글](https://github.com/masters2023-project-03-second-hand/second-hand-max-be-b/wiki/%ED%85%8C%EC%8A%A4%ED%8A%B8%EC%BD%94%EB%93%9C-%EC%84%B1%EB%8A%A5-%EA%B0%9C%EC%84%A0%EA%B8%B0)로 정리도 했습니다!
