### PR TITLE
상품 내용, 상태 수정

### DIFF
--- a/src/main/java/kr/codesquad/secondhand/application/item/ItemService.java
+++ b/src/main/java/kr/codesquad/secondhand/application/item/ItemService.java
@@ -8,10 +8,12 @@ import kr.codesquad.secondhand.domain.itemimage.ItemImage;
 import kr.codesquad.secondhand.domain.member.Member;
 import kr.codesquad.secondhand.exception.ErrorCode;
 import kr.codesquad.secondhand.exception.NotFoundException;
+import kr.codesquad.secondhand.exception.UnAuthorizedException;
 import kr.codesquad.secondhand.presentation.dto.CustomSlice;
 import kr.codesquad.secondhand.presentation.dto.item.ItemDetailResponse;
 import kr.codesquad.secondhand.presentation.dto.item.ItemRegisterRequest;
 import kr.codesquad.secondhand.presentation.dto.item.ItemResponse;
+import kr.codesquad.secondhand.presentation.dto.item.ItemUpdateRequest;
 import kr.codesquad.secondhand.repository.category.CategoryRepository;
 import kr.codesquad.secondhand.repository.item.ItemRepository;
 import kr.codesquad.secondhand.repository.item.querydsl.ItemPaginationRepository;
@@ -72,7 +74,6 @@ public class ItemService {
         return nextCursor;
     }
 
-
     @Transactional
     public ItemDetailResponse read(Long memberId, Long itemId) {
         Item item = itemRepository.findById(itemId)
@@ -85,5 +86,39 @@ public class ItemService {
             return ItemDetailResponse.toBuyerResponse(item, images);
         }
         return ItemDetailResponse.toSellerResponse(item, images);
+    }
+
+    @Transactional
+    public void update(List<MultipartFile> images, ItemUpdateRequest request, Long itemId, Long sellerId) {
+        // 상품 찾고 없으면 에러 던지기
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND, "상품을 찾을 수 없습니다."));
+
+        // 상품 작성자와 멤버가 같은지 확인, 아니면 에러 던지기
+        if (!item.isSeller(sellerId)) {
+            throw new UnAuthorizedException(ErrorCode.UNAUTHORIZED);
+        }
+
+        // deleteImageUrls에 있는 이미지 db에서 제거
+        List<String> deleteImageUrls = request.getDeleteImageUrls();
+        itemImageRepository.deleteByItem_IdAndImageUrlIn(itemId, deleteImageUrls);
+
+        // 추가하는 이미지 있으면 s3에 저장, db에 저장
+        if (images != null) {
+            List<String> itemImageUrls = imageService.uploadImages(images);
+            List<ItemImage> itemImages = itemImageUrls.stream()
+                    .map(url -> ItemImage.toEntity(url, item))
+                    .collect(Collectors.toList());
+            itemImageRepository.saveAllItemImages(itemImages);
+        }
+
+        // 썸네일 수정
+        if (item.isThumbnailDeleted(deleteImageUrls)) {
+            String thumbnail = itemImageRepository.findByItemId(itemId).get(0).getImageUrl();
+            item.updateThumbnail(thumbnail);
+        }
+
+        // 상품 제목, 내용, 가격 등 수정
+        item.update(request);
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/application/item/ItemService.java
+++ b/src/main/java/kr/codesquad/secondhand/application/item/ItemService.java
@@ -13,6 +13,7 @@ import kr.codesquad.secondhand.presentation.dto.CustomSlice;
 import kr.codesquad.secondhand.presentation.dto.item.ItemDetailResponse;
 import kr.codesquad.secondhand.presentation.dto.item.ItemRegisterRequest;
 import kr.codesquad.secondhand.presentation.dto.item.ItemResponse;
+import kr.codesquad.secondhand.presentation.dto.item.ItemStatusRequest;
 import kr.codesquad.secondhand.presentation.dto.item.ItemUpdateRequest;
 import kr.codesquad.secondhand.repository.category.CategoryRepository;
 import kr.codesquad.secondhand.repository.item.ItemRepository;
@@ -103,9 +104,18 @@ public class ItemService {
 
         if (item.isThumbnailDeleted(deleteImageUrls)) {
             String thumbnail = itemImageRepository.findByItemId(itemId).get(0).getImageUrl();
-            item.updateThumbnail(thumbnail);
+            item.changeThumbnail(thumbnail);
         }
         item.update(request);
+    }
+
+    @Transactional
+    public void updateStatus(ItemStatusRequest request, Long itemId, Long sellerId) {
+        Item item = findItem(itemId);
+        if (!item.isSeller(sellerId)) {
+            throw new UnAuthorizedException(ErrorCode.UNAUTHORIZED);
+        }
+        item.changeStatus(request.getStatus());
     }
 
     private Item findItem(Long itemId) {

--- a/src/main/java/kr/codesquad/secondhand/domain/item/Item.java
+++ b/src/main/java/kr/codesquad/secondhand/domain/item/Item.java
@@ -1,5 +1,6 @@
 package kr.codesquad.secondhand.domain.item;
 
+import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -14,6 +15,7 @@ import javax.persistence.Table;
 import kr.codesquad.secondhand.domain.AuditingFields;
 import kr.codesquad.secondhand.domain.member.Member;
 import kr.codesquad.secondhand.presentation.dto.item.ItemRegisterRequest;
+import kr.codesquad.secondhand.presentation.dto.item.ItemUpdateRequest;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -102,5 +104,23 @@ public class Item extends AuditingFields {
 
     public boolean isSeller(Long memberId) {
         return this.member.getId() == memberId;
+    }
+
+    public void update(ItemUpdateRequest request) {
+        this.title = request.getTitle();
+        this.content = request.getContent();
+        this.price = request.getPrice();
+        this.tradingRegion = request.getRegion();
+        this.status = ItemStatus.of(request.getStatus());
+        this.categoryName = request.getCategoryName();
+    }
+
+    public boolean isThumbnailDeleted(List<String> deleteImageUrls) {
+        return deleteImageUrls.stream()
+                .anyMatch(deleteImage -> thumbnailUrl.equals(deleteImage));
+    }
+
+    public void updateThumbnail(String imageUrl) {
+        this.thumbnailUrl = imageUrl;
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/domain/item/Item.java
+++ b/src/main/java/kr/codesquad/secondhand/domain/item/Item.java
@@ -120,7 +120,11 @@ public class Item extends AuditingFields {
                 .anyMatch(deleteImage -> thumbnailUrl.equals(deleteImage));
     }
 
-    public void updateThumbnail(String imageUrl) {
+    public void changeThumbnail(String imageUrl) {
         this.thumbnailUrl = imageUrl;
+    }
+
+    public void changeStatus(String status) {
+        this.status = ItemStatus.of(status);
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/exception/ErrorCode.java
+++ b/src/main/java/kr/codesquad/secondhand/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
     INVALID_LOGIN_DATA("로그인 정보가 일치하지 않습니다."),
     DUPLICATED_LOGIN_ID("중복된 아이디입니다."),
     NOT_LOGIN("로그인된 상태가 아닙니다."),
+    UNAUTHORIZED("수정 권한이 없습니다."),
 
     // COMMON
     INVALID_PARAMETER("유효한 파라미터값이 아닙니다."),

--- a/src/main/java/kr/codesquad/secondhand/exception/ForbiddenException.java
+++ b/src/main/java/kr/codesquad/secondhand/exception/ForbiddenException.java
@@ -1,0 +1,8 @@
+package kr.codesquad.secondhand.exception;
+
+public class ForbiddenException extends SecondHandException {
+
+    public ForbiddenException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/kr/codesquad/secondhand/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/codesquad/secondhand/exception/GlobalExceptionHandler.java
@@ -37,4 +37,10 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .body(new ErrorResponse(404, e.getMessage()));
     }
+
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<ErrorResponse> handleForbiddenException(ForbiddenException e) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(new ErrorResponse(403, e.getMessage()));
+    }
 }

--- a/src/main/java/kr/codesquad/secondhand/presentation/ItemController.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/ItemController.java
@@ -11,6 +11,7 @@ import kr.codesquad.secondhand.presentation.dto.CustomSlice;
 import kr.codesquad.secondhand.presentation.dto.item.ItemDetailResponse;
 import kr.codesquad.secondhand.presentation.dto.item.ItemRegisterRequest;
 import kr.codesquad.secondhand.presentation.dto.item.ItemResponse;
+import kr.codesquad.secondhand.presentation.dto.item.ItemStatusRequest;
 import kr.codesquad.secondhand.presentation.dto.item.ItemUpdateRequest;
 import kr.codesquad.secondhand.presentation.support.Auth;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -78,10 +81,16 @@ public class ItemController {
                                                         @PathVariable Long itemId,
                                                         @Auth Long memberId) {
        itemService.update(
-               images.orElse(null),
-               item,
-               itemId,
-               memberId);
+               images.orElse(null), item, itemId, memberId);
+       return ResponseEntity.ok()
+               .body(new ApiResponse<>(HttpStatus.OK.value()));
+    }
+
+    @PutMapping("/{itemId}/status")
+    public ResponseEntity<ApiResponse<Void>> updateItemStatus(@Valid @RequestBody ItemStatusRequest status,
+                                                              @PathVariable Long itemId,
+                                                              @Auth Long memberId) {
+        itemService.updateStatus(status, itemId, memberId);
         return ResponseEntity.ok()
                 .body(new ApiResponse<>(HttpStatus.OK.value()));
     }

--- a/src/main/java/kr/codesquad/secondhand/presentation/ItemController.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/ItemController.java
@@ -11,6 +11,7 @@ import kr.codesquad.secondhand.presentation.dto.CustomSlice;
 import kr.codesquad.secondhand.presentation.dto.item.ItemDetailResponse;
 import kr.codesquad.secondhand.presentation.dto.item.ItemRegisterRequest;
 import kr.codesquad.secondhand.presentation.dto.item.ItemResponse;
+import kr.codesquad.secondhand.presentation.dto.item.ItemUpdateRequest;
 import kr.codesquad.secondhand.presentation.support.Auth;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -65,5 +66,22 @@ public class ItemController {
                         HttpStatus.OK.value(),
                         itemService.read(memberId, itemId))
                 );
+    }
+
+    @PostMapping(consumes = {
+            MediaType.MULTIPART_FORM_DATA_VALUE,
+            MediaType.APPLICATION_JSON_VALUE
+    })
+    public ResponseEntity<ApiResponse<Void>> updateItem(@RequestPart Optional<List<MultipartFile>> images,
+                                                        @Valid @RequestPart ItemUpdateRequest item,
+                                                        @PathVariable Long itemId,
+                                                        @Auth Long memberId) {
+       itemService.update(
+               images.orElse(null),
+               item,
+               itemId,
+               memberId);
+        return ResponseEntity.ok()
+                .body(new ApiResponse<>(HttpStatus.OK.value()));
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/presentation/ItemController.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/ItemController.java
@@ -80,8 +80,7 @@ public class ItemController {
                                                         @Valid @RequestPart ItemUpdateRequest item,
                                                         @PathVariable Long itemId,
                                                         @Auth Long memberId) {
-       itemService.update(
-               images.orElse(null), item, itemId, memberId);
+       itemService.update(images.orElse(null), item, itemId, memberId);
        return ResponseEntity.ok()
                .body(new ApiResponse<>(HttpStatus.OK.value()));
     }

--- a/src/main/java/kr/codesquad/secondhand/presentation/ItemController.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/ItemController.java
@@ -18,6 +18,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -68,7 +69,7 @@ public class ItemController {
                 );
     }
 
-    @PostMapping(consumes = {
+    @PatchMapping(consumes = {
             MediaType.MULTIPART_FORM_DATA_VALUE,
             MediaType.APPLICATION_JSON_VALUE
     })

--- a/src/main/java/kr/codesquad/secondhand/presentation/dto/item/ItemDetailResponse.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/dto/item/ItemDetailResponse.java
@@ -25,12 +25,12 @@ public class ItemDetailResponse {
     private final int chatCount;
     private final int wishCount;
     private final int viewCount;
-    private final int price;
+    private final Integer price;
 
     @Builder
     private ItemDetailResponse(boolean isSeller, List<String> imageUrls, String seller, String status, String title,
                                String categoryName, LocalDateTime createdAt, String content,
-                               int chatCount, int wishCount, int viewCount, int price) {
+                               int chatCount, int wishCount, int viewCount, Integer price) {
         this.isSeller = isSeller;
         this.imageUrls = imageUrls;
         this.seller = seller;

--- a/src/main/java/kr/codesquad/secondhand/presentation/dto/item/ItemStatusRequest.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/dto/item/ItemStatusRequest.java
@@ -1,0 +1,15 @@
+package kr.codesquad.secondhand.presentation.dto.item;
+
+import javax.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ItemStatusRequest {
+
+    @NotBlank(message = "상품의 판매 상태는 비어있을 수 없습니다.")
+    private String status;
+}

--- a/src/main/java/kr/codesquad/secondhand/presentation/dto/item/ItemUpdateRequest.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/dto/item/ItemUpdateRequest.java
@@ -1,0 +1,38 @@
+package kr.codesquad.secondhand.presentation.dto.item;
+
+import java.util.List;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ItemUpdateRequest {
+
+    @NotBlank(message = "상품의 제목은 비어있을 수 없습니다.")
+    @Size(max = 100, message = "상품 제목의 길이는 100자를 넘을 수 없습니다.")
+    private String title;
+
+    private Integer price;
+
+    @Size(max = 2000, message = "상품 내용의 길이는 2000자를 넘을 수 없습니다.")
+    private String content;
+
+    @NotBlank(message = "상품의 판매 지역은 비어있을 수 없습니다.")
+    private String region;
+
+    @NotBlank(message = "상품의 판매 상태는 비어있을 수 없습니다.")
+    private String status;
+
+    @NotNull(message = "상품의 카테고리 아이디를 포함해 요청해주세요.")
+    private Integer categoryId;
+
+    @NotBlank(message = "상품의 카테고리 이름은 비어있을 수 없습니다.")
+    private String categoryName;
+
+    private List<String> deleteImageUrls;
+}

--- a/src/main/java/kr/codesquad/secondhand/repository/itemimage/ItemImageRepository.java
+++ b/src/main/java/kr/codesquad/secondhand/repository/itemimage/ItemImageRepository.java
@@ -7,4 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ItemImageRepository extends JpaRepository<ItemImage, Long>, ItemImageRepositoryCustom {
 
     List<ItemImage> findByItemId(Long itemId);
+    void deleteByItem_IdAndImageUrlIn(Long itemId, List<String> deleteImageUrls);
 }

--- a/src/main/java/kr/codesquad/secondhand/repository/itemimage/ItemImageRepository.java
+++ b/src/main/java/kr/codesquad/secondhand/repository/itemimage/ItemImageRepository.java
@@ -7,5 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ItemImageRepository extends JpaRepository<ItemImage, Long>, ItemImageRepositoryCustom {
 
     List<ItemImage> findByItemId(Long itemId);
+
     void deleteByItem_IdAndImageUrlIn(Long itemId, List<String> deleteImageUrls);
 }

--- a/src/test/java/kr/codesquad/secondhand/application/item/ItemServiceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/application/item/ItemServiceTest.java
@@ -128,11 +128,7 @@ class ItemServiceTest extends ApplicationTestSupport {
     void given_whenSeller_thenItemDetails() {
         // given
         given(s3Uploader.uploadImageFiles(anyList())).willReturn(List.of("url1", "url2", "url3"));
-        Member member = supportRepository.save(Member.builder()
-                .email("bruni@secondhand.com")
-                .loginId("bruni")
-                .profileUrl("profile-url")
-                .build());
+        Member member = signup();
         itemService.register(createFakeImage(), FixtureFactory.createItemRegisterRequest(), member.getId());
 
         // when
@@ -151,11 +147,7 @@ class ItemServiceTest extends ApplicationTestSupport {
     void given_whenBuyer_thenItemDetails() {
         // given
         given(s3Uploader.uploadImageFiles(anyList())).willReturn(List.of("url1", "url2", "url3"));
-        Member seller = supportRepository.save(Member.builder()
-                .email("bruni@secondhand.com")
-                .loginId("bruni")
-                .profileUrl("profile-url")
-                .build());
+        Member seller = signup();
         itemService.register(createFakeImage(), FixtureFactory.createItemRegisterRequest(), seller.getId());
         Member buyer = supportRepository.save(Member.builder()
                 .email("joy@secondhand.com")
@@ -170,6 +162,29 @@ class ItemServiceTest extends ApplicationTestSupport {
         assertAll(
                 () -> assertThat(response.isSeller()).isFalse(),
                 () -> assertThat(response.getViewCount()).isEqualTo(1)
+        );
+    }
+
+    @DisplayName("상품을 수정하면 상품정보가 db에 업데이트되고 삭제 이미지가 db에서 제거된다.")
+    @Test
+    void given_whenUpdateItem_thenSuccess() {
+        // given
+        given(s3Uploader.uploadImageFiles(anyList())).willReturn(List.of("url1", "url2", "url3"));
+        Member member = signup();
+        itemService.register(createFakeImage(), FixtureFactory.createItemRegisterRequest(), member.getId());
+
+        // when
+        itemService.update(null, FixtureFactory.createItemUpdateRequest(), 1L, member.getId());
+
+        // then
+        Optional<Item> item = supportRepository.findById(Item.class, 1L);
+        List<ItemImage> images = supportRepository.findAll(ItemImage.class);
+
+        assertAll(
+                () -> assertThat(item).isPresent(),
+                () -> assertThat(item.get().getTitle()).isEqualTo("수정제목"),
+                () -> assertThat(item.get().getThumbnailUrl()).isEqualTo("url3"),
+                () -> assertThat(images).hasSize(1)
         );
     }
 

--- a/src/test/java/kr/codesquad/secondhand/application/item/ItemServiceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/application/item/ItemServiceTest.java
@@ -208,7 +208,6 @@ class ItemServiceTest extends ApplicationTestSupport {
         Item item = supportRepository.findById(Item.class, 1L).get();
 
         assertThat(item.getStatus().getStatus()).isEqualTo("예약중");
-
     }
 
     @DisplayName("작성자가 아닌 사람이 상품을 수정하려하면 예외를 던진다.")
@@ -229,7 +228,6 @@ class ItemServiceTest extends ApplicationTestSupport {
         assertThatThrownBy(() -> itemService.updateStatus(request, 1L, buyer.getId()))
                 .isInstanceOf(UnAuthorizedException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.UNAUTHORIZED);
-
     }
 
     private List<MultipartFile> createFakeImage() {

--- a/src/test/java/kr/codesquad/secondhand/fixture/FixtureFactory.java
+++ b/src/test/java/kr/codesquad/secondhand/fixture/FixtureFactory.java
@@ -1,9 +1,11 @@
 package kr.codesquad.secondhand.fixture;
 
+import java.util.List;
 import kr.codesquad.secondhand.domain.item.Item;
 import kr.codesquad.secondhand.domain.item.ItemStatus;
 import kr.codesquad.secondhand.domain.member.Member;
 import kr.codesquad.secondhand.presentation.dto.item.ItemRegisterRequest;
+import kr.codesquad.secondhand.presentation.dto.item.ItemUpdateRequest;
 
 public class FixtureFactory {
 
@@ -37,5 +39,18 @@ public class FixtureFactory {
                 .loginId("23Yong")
                 .profileUrl("image-url")
                 .build();
+    }
+
+    public static ItemUpdateRequest createItemUpdateRequest() {
+        return new ItemUpdateRequest(
+                "수정제목",
+                10000,
+                "바람이 시원한 선풍기",
+                "범안 1동",
+                "판매중",
+                1,
+                "가전/잡화",
+                List.of("url1", "url2")
+        );
     }
 }


### PR DESCRIPTION
## Issues
- #32 

## What is this PR? 👓
상품 내용과 상태 수정 기능에 대한 pr입니다.

## Key changes 🔑
- 상품 상세 내용 수정 기능 추가
- 상품 상태 수정 기능 추가
- 테스트 코드 작성

## To reviewers 👋
- 상품 상세 내용을 수정하는 ItemService의 `update`메서드에서는 상품 찾기 -> 상품 수정권한 확인 -> 삭제 이미지 db에서 삭제 -> 새로운 이미지 저장 -> 썸네일 수정 -> 상품 상세 내용 수정으로 진행됩니다! 혹시 순서를 바꿀만한 부분이 있으면 알려주세요:)
- 이미지를 db에서 삭제할 때, `deleteByItem_IdAndImageUrlIn` 메서드로 itemId와 삭제 이미지 리스트를 받아서 삭제하는데 다른 방법이 있을까요? jpa를 아직 잘 몰라서 더 좋은 방법이 있을 것 같은데 이 방법밖에 모르겠어요...🥹