### PR TITLE
관심상품 등록/해제

### DIFF
--- a/src/main/java/kr/codesquad/secondhand/application/wishitem/WishItemService.java
+++ b/src/main/java/kr/codesquad/secondhand/application/wishitem/WishItemService.java
@@ -3,8 +3,6 @@ package kr.codesquad.secondhand.application.wishitem;
 import kr.codesquad.secondhand.domain.WishItem;
 import kr.codesquad.secondhand.domain.item.Item;
 import kr.codesquad.secondhand.domain.member.Member;
-import kr.codesquad.secondhand.repository.item.ItemRepository;
-import kr.codesquad.secondhand.repository.member.MemberRepository;
 import kr.codesquad.secondhand.repository.wishitem.WishItemRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,8 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class WishItemService {
 
     private final WishItemRepository wishItemRepository;
-    private final MemberRepository memberRepository;
-    private final ItemRepository itemRepository;
 
     @Transactional
     public void registerWishItem(Long itemId, Long memberId) {

--- a/src/main/java/kr/codesquad/secondhand/application/wishitem/WishItemService.java
+++ b/src/main/java/kr/codesquad/secondhand/application/wishitem/WishItemService.java
@@ -1,0 +1,38 @@
+package kr.codesquad.secondhand.application.wishitem;
+
+import kr.codesquad.secondhand.domain.WishItem;
+import kr.codesquad.secondhand.domain.item.Item;
+import kr.codesquad.secondhand.domain.member.Member;
+import kr.codesquad.secondhand.repository.item.ItemRepository;
+import kr.codesquad.secondhand.repository.member.MemberRepository;
+import kr.codesquad.secondhand.repository.wishitem.WishItemRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class WishItemService {
+
+    private final WishItemRepository wishItemRepository;
+    private final MemberRepository memberRepository;
+    private final ItemRepository itemRepository;
+
+    @Transactional
+    public void registerWishItem(Long itemId, Long memberId) {
+        wishItemRepository.save(WishItem.builder()
+                .item(Item.builder()
+                        .id(itemId)
+                        .build())
+                .member(Member.builder()
+                        .id(memberId)
+                        .build())
+                .build());
+    }
+
+    @Transactional
+    public void removeWishItem(Long itemId, Long memberId) {
+        wishItemRepository.deleteByItemIdAndMemberId(itemId, memberId);
+    }
+}

--- a/src/main/java/kr/codesquad/secondhand/domain/WishItem.java
+++ b/src/main/java/kr/codesquad/secondhand/domain/WishItem.java
@@ -1,0 +1,42 @@
+package kr.codesquad.secondhand.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import kr.codesquad.secondhand.domain.item.Item;
+import kr.codesquad.secondhand.domain.member.Member;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "wish_item")
+@Entity
+public class WishItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn(name = "memeber_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    @JoinColumn(name = "item_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Item item;
+
+    @Builder
+    private WishItem(Long id, Member member, Item item) {
+        this.id = id;
+        this.member = member;
+        this.item = item;
+    }
+}

--- a/src/main/java/kr/codesquad/secondhand/domain/item/Item.java
+++ b/src/main/java/kr/codesquad/secondhand/domain/item/Item.java
@@ -75,8 +75,9 @@ public class Item extends AuditingFields {
     private Member member;
 
     @Builder
-    private Item(String title, String content, Long price, String tradingRegion,
+    private Item(Long id, String title, String content, Long price, String tradingRegion,
                  ItemStatus status, String categoryName, String thumbnailUrl, Member member) {
+        this.id = id;
         this.title = title;
         this.content = content;
         this.price = price;

--- a/src/main/java/kr/codesquad/secondhand/presentation/WishItemController.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/WishItemController.java
@@ -1,0 +1,34 @@
+package kr.codesquad.secondhand.presentation;
+
+import kr.codesquad.secondhand.application.wishitem.WishItemService;
+import kr.codesquad.secondhand.presentation.dto.ApiResponse;
+import kr.codesquad.secondhand.presentation.support.Auth;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/wishes")
+@RestController
+public class WishItemController {
+
+    private final WishItemService wishItemService;
+
+    @ResponseStatus(value = HttpStatus.OK)
+    @PostMapping("/{itemId}")
+    public ApiResponse<Void> changeWishStatusOfItem(@RequestParam("wish") String isWish,
+                                                    @PathVariable Long itemId,
+                                                    @Auth Long memberId) {
+        if (isWish.equals("yes")) {
+            wishItemService.registerWishItem(itemId, memberId);
+            return new ApiResponse<>(HttpStatus.OK.value());
+        }
+        wishItemService.removeWishItem(itemId, memberId);
+        return new ApiResponse<>(HttpStatus.OK.value());
+    }
+}

--- a/src/main/java/kr/codesquad/secondhand/repository/wishitem/WishItemRepository.java
+++ b/src/main/java/kr/codesquad/secondhand/repository/wishitem/WishItemRepository.java
@@ -1,0 +1,14 @@
+package kr.codesquad.secondhand.repository.wishitem;
+
+import kr.codesquad.secondhand.domain.WishItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface WishItemRepository extends JpaRepository<WishItem, Long> {
+
+    @Modifying
+    @Query("DELETE FROM WishItem wishItem WHERE wishItem.item.id = :itemId AND wishItem.member.id = :memberId")
+    void deleteByItemIdAndMemberId(@Param("itemId") Long itemId, @Param("memberId") Long memberId);
+}

--- a/src/test/java/kr/codesquad/secondhand/acceptance/AcceptanceTestSupport.java
+++ b/src/test/java/kr/codesquad/secondhand/acceptance/AcceptanceTestSupport.java
@@ -6,6 +6,7 @@ import kr.codesquad.secondhand.application.auth.NaverRequester;
 import kr.codesquad.secondhand.application.image.S3Uploader;
 import kr.codesquad.secondhand.domain.member.Member;
 import kr.codesquad.secondhand.fixture.FixtureFactory;
+import kr.codesquad.secondhand.infrastructure.jwt.JwtProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
@@ -23,6 +24,9 @@ public abstract class AcceptanceTestSupport {
 
     @Autowired
     protected ObjectMapper objectMapper;
+
+    @Autowired
+    protected JwtProvider jwtProvider;
 
     protected Member signup() {
         return supportRepository.save(FixtureFactory.createMember());

--- a/src/test/java/kr/codesquad/secondhand/acceptance/ItemAcceptanceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/acceptance/ItemAcceptanceTest.java
@@ -15,18 +15,13 @@ import java.io.IOException;
 import java.util.List;
 import kr.codesquad.secondhand.domain.member.Member;
 import kr.codesquad.secondhand.fixture.FixtureFactory;
-import kr.codesquad.secondhand.infrastructure.jwt.JwtProvider;
 import org.apache.http.HttpHeaders;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 
 public class ItemAcceptanceTest extends AcceptanceTestSupport {
-
-    @Autowired
-    private JwtProvider jwtProvider;
 
     private File createFakeFile() throws IOException {
         return File.createTempFile("test-image", ".png");

--- a/src/test/java/kr/codesquad/secondhand/acceptance/WishItemAcceptanceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/acceptance/WishItemAcceptanceTest.java
@@ -1,0 +1,65 @@
+package kr.codesquad.secondhand.acceptance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.restassured.RestAssured;
+import kr.codesquad.secondhand.domain.WishItem;
+import kr.codesquad.secondhand.domain.item.Item;
+import kr.codesquad.secondhand.domain.member.Member;
+import kr.codesquad.secondhand.fixture.FixtureFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+
+public class WishItemAcceptanceTest extends AcceptanceTestSupport {
+
+    @DisplayName("관심 상품 등록/해제 쿼리파라미터가 주어지면 어떤 상품을 관심상품으로 등록할 때 성공한다.")
+    @Test
+    void givenIsWishItemQueryParam_whenRegisterWishItem_thenSuccess() {
+        // given
+        Member member = signup();
+        supportRepository.save(FixtureFactory.createItem("초코 브라우니", "식품", member));
+
+        var request = RestAssured
+                .given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtProvider.createAccessToken(1L))
+                .queryParam("wish", "yes");
+
+        // when
+        var response = request
+                .when()
+                .post("/api/wishes/1")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(200);
+    }
+
+    @DisplayName("관심 상품 등록/해제 쿼리파라미터가 주어지면 어떤 상품을 관심상품에서 해제할 때 성공한다.")
+    @Test
+    void givenIsWishItemQueryParam_whenRemoveWishItem_thenSuccess() {
+        // given
+        Member member = signup();
+        Item item = supportRepository.save(FixtureFactory.createItem("초코 브라우니", "식품", member));
+        supportRepository.save(WishItem.builder()
+                .item(item)
+                .member(member)
+                .build());
+
+        var request = RestAssured
+                .given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtProvider.createAccessToken(1L))
+                .queryParam("wish", "no");
+
+        // when
+        var response = request
+                .when()
+                .post("/api/wishes/1")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(200);
+    }
+}

--- a/src/test/java/kr/codesquad/secondhand/application/wishitem/WishItemServiceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/application/wishitem/WishItemServiceTest.java
@@ -1,0 +1,57 @@
+package kr.codesquad.secondhand.application.wishitem;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.Optional;
+import kr.codesquad.secondhand.application.ApplicationTestSupport;
+import kr.codesquad.secondhand.domain.WishItem;
+import kr.codesquad.secondhand.domain.item.Item;
+import kr.codesquad.secondhand.domain.member.Member;
+import kr.codesquad.secondhand.fixture.FixtureFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class WishItemServiceTest extends ApplicationTestSupport {
+
+    @Autowired
+    private WishItemService wishItemService;
+
+    @DisplayName("아이템을 관심 상품으로 등록하는데 성공한다.")
+    @Test
+    void given_whenRegisterWishItem_thenSuccess() {
+        // given
+        Member member = supportRepository.save(FixtureFactory.createMember());
+        supportRepository.save(FixtureFactory.createItem("초코 브라우니", "식품", member));
+
+        // when
+        wishItemService.registerWishItem(1L, 1L);
+
+        // then
+        Optional<WishItem> wishItem = supportRepository.findById(WishItem.class, 1L);
+
+        assertAll(
+                () -> assertThat(wishItem).isPresent(),
+                () -> assertThat(wishItem.get().getMember().getId()).isEqualTo(1L),
+                () -> assertThat(wishItem.get().getItem().getId()).isEqualTo(1L)
+        );
+    }
+
+    @DisplayName("아이템을 관심 상품에서 제거하는데 성공한다.")
+    @Test
+    void given_whenRemoveWishItem_thenSuccess() {
+        // given
+        Member member = supportRepository.save(FixtureFactory.createMember());
+        Item item = supportRepository.save(FixtureFactory.createItem("초코 브라우니", "식품", member));
+        supportRepository.save(WishItem.builder().item(item).member(member).build());
+
+        // when
+        wishItemService.removeWishItem(1L, 1L);
+
+        // then
+        Optional<WishItem> wishItem = supportRepository.findById(WishItem.class, 1L);
+
+        assertThat(wishItem).isNotPresent();
+    }
+}


### PR DESCRIPTION
## Issues
- #50 

## What is this PR? 👓
관심상품으로 등록/해제하는 기능에 대한 PR입니다.

## Key changes 🔑
- 로그인된 사용자에 대해 관심상품으로 등록하는 기능
- 로그인된 사용자에 대해 관심상품에서 해제하는 기능

## To reviewers 👋
`WishItemRepository`에서 `deleteByItemIdAndMemberId`메서드를 `@Query`와 `@Modifying` 애노테이션을 사용해서 작성했습니다.
그냥 `deleteByItemIdAndMemberId`를 사용했을 때 `WishItem`엔티티를 가져오기 위해 `item`, `member`테이블과 left join을 수행한 후 DELETE쿼리가 나가기 때문에 위와 같이 수행했습니다!
