### PR TITLE
로그아웃 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,9 @@ dependencies {
     // validation
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation'
 
+    //redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/kr/codesquad/secondhand/application/auth/TokenService.java
+++ b/src/main/java/kr/codesquad/secondhand/application/auth/TokenService.java
@@ -1,15 +1,21 @@
 package kr.codesquad.secondhand.application.auth;
 
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import javax.servlet.http.HttpServletRequest;
 import kr.codesquad.secondhand.exception.ErrorCode;
 import kr.codesquad.secondhand.exception.UnAuthorizedException;
 import kr.codesquad.secondhand.infrastructure.jwt.JwtProvider;
 import kr.codesquad.secondhand.presentation.dto.token.AccessTokenResponse;
 import kr.codesquad.secondhand.repository.token.TokenRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Map;
+import org.springframework.util.StringUtils;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -18,6 +24,7 @@ public class TokenService {
 
     private final TokenRepository tokenRepository;
     private final JwtProvider jwtProvider;
+    private final RedisTemplate redisTemplate;
 
     public AccessTokenResponse renewAccessToken(final String refreshToken) {
         jwtProvider.validateToken(refreshToken);
@@ -28,5 +35,23 @@ public class TokenService {
             throw new UnAuthorizedException(ErrorCode.INVALID_TOKEN);
         }
         return new AccessTokenResponse(jwtProvider.createAccessToken(memberId));
+    }
+
+    @Transactional
+    public void logout(HttpServletRequest request, Long memberId) {
+        String accessToken = extractJwt(request);
+        Long expiration = jwtProvider.getExpiration(accessToken);
+        redisTemplate.opsForValue().set(accessToken, "logout", expiration, TimeUnit.MILLISECONDS);
+        tokenRepository.deleteByMemberId(memberId);
+    }
+
+    private String extractJwt(HttpServletRequest request) {
+        final String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if (!StringUtils.hasText(header) || !header.toLowerCase().startsWith("bearer")) {
+            throw new UnAuthorizedException(ErrorCode.INVALID_AUTH_HEADER);
+        }
+
+        return header.split(" ")[1];
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/application/auth/TokenService.java
+++ b/src/main/java/kr/codesquad/secondhand/application/auth/TokenService.java
@@ -1,21 +1,15 @@
 package kr.codesquad.secondhand.application.auth;
 
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
-import javax.servlet.http.HttpServletRequest;
 import kr.codesquad.secondhand.exception.ErrorCode;
 import kr.codesquad.secondhand.exception.UnAuthorizedException;
 import kr.codesquad.secondhand.infrastructure.jwt.JwtProvider;
 import kr.codesquad.secondhand.presentation.dto.token.AccessTokenResponse;
 import kr.codesquad.secondhand.repository.token.TokenRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Map;
-import org.springframework.util.StringUtils;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)

--- a/src/main/java/kr/codesquad/secondhand/application/auth/TokenService.java
+++ b/src/main/java/kr/codesquad/secondhand/application/auth/TokenService.java
@@ -24,7 +24,6 @@ public class TokenService {
 
     private final TokenRepository tokenRepository;
     private final JwtProvider jwtProvider;
-    private final RedisTemplate redisTemplate;
 
     public AccessTokenResponse renewAccessToken(final String refreshToken) {
         jwtProvider.validateToken(refreshToken);
@@ -35,23 +34,5 @@ public class TokenService {
             throw new UnAuthorizedException(ErrorCode.INVALID_TOKEN);
         }
         return new AccessTokenResponse(jwtProvider.createAccessToken(memberId));
-    }
-
-    @Transactional
-    public void logout(HttpServletRequest request, Long memberId) {
-        String accessToken = extractJwt(request);
-        Long expiration = jwtProvider.getExpiration(accessToken);
-        redisTemplate.opsForValue().set(accessToken, "logout", expiration, TimeUnit.MILLISECONDS);
-        tokenRepository.deleteByMemberId(memberId);
-    }
-
-    private String extractJwt(HttpServletRequest request) {
-        final String header = request.getHeader(HttpHeaders.AUTHORIZATION);
-
-        if (!StringUtils.hasText(header) || !header.toLowerCase().startsWith("bearer")) {
-            throw new UnAuthorizedException(ErrorCode.INVALID_AUTH_HEADER);
-        }
-
-        return header.split(" ")[1];
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/config/OauthConfig.java
+++ b/src/main/java/kr/codesquad/secondhand/config/OauthConfig.java
@@ -1,6 +1,6 @@
 package kr.codesquad.secondhand.config;
 
-import kr.codesquad.secondhand.infrastructure.OauthProperties;
+import kr.codesquad.secondhand.infrastructure.properties.OauthProperties;
 import kr.codesquad.secondhand.infrastructure.OauthProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;

--- a/src/main/java/kr/codesquad/secondhand/config/RedisConfig.java
+++ b/src/main/java/kr/codesquad/secondhand/config/RedisConfig.java
@@ -1,0 +1,33 @@
+package kr.codesquad.secondhand.config;
+
+import kr.codesquad.secondhand.infrastructure.properties.RedisProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@RequiredArgsConstructor
+@EnableRedisRepositories
+@Configuration
+public class RedisConfig {
+
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/kr/codesquad/secondhand/infrastructure/OauthProvider.java
+++ b/src/main/java/kr/codesquad/secondhand/infrastructure/OauthProvider.java
@@ -1,5 +1,6 @@
 package kr.codesquad.secondhand.infrastructure;
 
+import kr.codesquad.secondhand.infrastructure.properties.OauthProperties;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/src/main/java/kr/codesquad/secondhand/infrastructure/jwt/JwtExtractor.java
+++ b/src/main/java/kr/codesquad/secondhand/infrastructure/jwt/JwtExtractor.java
@@ -1,0 +1,21 @@
+package kr.codesquad.secondhand.infrastructure.jwt;
+
+import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.StringUtils;
+
+public class JwtExtractor {
+
+    public static final String BEARER = "bearer";
+
+    public static Optional<String> extract(HttpServletRequest request) {
+        final String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if (!StringUtils.hasText(header) || !header.toLowerCase().startsWith(BEARER)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(header.split(" ")[1]);
+    }
+}

--- a/src/main/java/kr/codesquad/secondhand/infrastructure/jwt/JwtExtractor.java
+++ b/src/main/java/kr/codesquad/secondhand/infrastructure/jwt/JwtExtractor.java
@@ -5,7 +5,7 @@ import javax.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.util.StringUtils;
 
-public class JwtExtractor {
+public final class JwtExtractor {
 
     public static final String BEARER = "bearer";
 
@@ -18,4 +18,6 @@ public class JwtExtractor {
 
         return Optional.of(header.split(" ")[1]);
     }
+
+    private JwtExtractor() {}
 }

--- a/src/main/java/kr/codesquad/secondhand/infrastructure/jwt/JwtProvider.java
+++ b/src/main/java/kr/codesquad/secondhand/infrastructure/jwt/JwtProvider.java
@@ -90,7 +90,7 @@ public class JwtProvider {
         return expiration.getTime() - now;
     }
 
-    public void validBlackToken(String accessToken) {
+    public void validateBlackToken(String accessToken) {
         if (redisTemplate.hasKey(accessToken)) {
             throw new UnAuthorizedException(ErrorCode.NOT_LOGIN);
         }

--- a/src/main/java/kr/codesquad/secondhand/infrastructure/jwt/JwtProvider.java
+++ b/src/main/java/kr/codesquad/secondhand/infrastructure/jwt/JwtProvider.java
@@ -1,18 +1,21 @@
 package kr.codesquad.secondhand.infrastructure.jwt;
 
-import io.jsonwebtoken.*;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
+import javax.crypto.SecretKey;
 import kr.codesquad.secondhand.exception.ErrorCode;
 import kr.codesquad.secondhand.exception.UnAuthorizedException;
 import kr.codesquad.secondhand.infrastructure.properties.JwtProperties;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
-
-import javax.crypto.SecretKey;
-import java.nio.charset.StandardCharsets;
-import java.util.Collections;
-import java.util.Date;
-import java.util.Map;
 
 
 @Component
@@ -38,7 +41,7 @@ public class JwtProvider {
                 .signWith(secretKey, SignatureAlgorithm.HS256)
                 .setIssuedAt(now)
                 .setExpiration(accessTokenExpiration)
-                .setClaims(Map.of("memberId", memberId))
+                .addClaims(Map.of("memberId", memberId))
                 .compact();
     }
 
@@ -50,7 +53,7 @@ public class JwtProvider {
                 .signWith(secretKey, SignatureAlgorithm.HS256)
                 .setIssuedAt(now)
                 .setExpiration(refreshTokenExpiration)
-                .setClaims(Map.of("memberId", memberId))
+                .addClaims(Map.of("memberId", memberId))
                 .compact();
     }
 

--- a/src/main/java/kr/codesquad/secondhand/infrastructure/properties/OauthProperties.java
+++ b/src/main/java/kr/codesquad/secondhand/infrastructure/properties/OauthProperties.java
@@ -1,4 +1,4 @@
-package kr.codesquad.secondhand.infrastructure;
+package kr.codesquad.secondhand.infrastructure.properties;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/kr/codesquad/secondhand/infrastructure/properties/RedisProperties.java
+++ b/src/main/java/kr/codesquad/secondhand/infrastructure/properties/RedisProperties.java
@@ -1,0 +1,16 @@
+package kr.codesquad.secondhand.infrastructure.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Setter
+@Getter
+@ConfigurationProperties(prefix = "redis")
+@Component
+public class RedisProperties {
+
+    private int port;
+    private String host;
+}

--- a/src/main/java/kr/codesquad/secondhand/infrastructure/properties/RedisProperties.java
+++ b/src/main/java/kr/codesquad/secondhand/infrastructure/properties/RedisProperties.java
@@ -1,25 +1,19 @@
 package kr.codesquad.secondhand.infrastructure.properties;
 
 import lombok.Getter;
-import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.ConstructorBinding;
-import org.springframework.stereotype.Component;
 
-@Setter
 @Getter
-@Component
 @ConfigurationProperties(prefix = "redis")
 public class RedisProperties {
 
     private int port;
     private String host;
 
-    public int getPort() {
-        return this.port;
-    }
-
-    public String getHost() {
-        return this.host;
+    @ConstructorBinding
+    public RedisProperties(int port, String host) {
+        this.port = port;
+        this.host = host;
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/infrastructure/properties/RedisProperties.java
+++ b/src/main/java/kr/codesquad/secondhand/infrastructure/properties/RedisProperties.java
@@ -3,14 +3,23 @@ package kr.codesquad.secondhand.infrastructure.properties;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
 import org.springframework.stereotype.Component;
 
 @Setter
 @Getter
-@ConfigurationProperties(prefix = "redis")
 @Component
+@ConfigurationProperties(prefix = "redis")
 public class RedisProperties {
 
     private int port;
     private String host;
+
+    public int getPort() {
+        return this.port;
+    }
+
+    public String getHost() {
+        return this.host;
+    }
 }

--- a/src/main/java/kr/codesquad/secondhand/presentation/AuthController.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/AuthController.java
@@ -65,7 +65,7 @@ public class AuthController {
     @ResponseStatus(value = HttpStatus.OK)
     @PostMapping("/logout")
     public ApiResponse<Void> logout(HttpServletRequest request, @Auth Long memberId) {
-        tokenService.logout(request, memberId);
+        authService.logout(request, memberId);
         return new ApiResponse<>(HttpStatus.OK.value());
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/presentation/AuthController.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/AuthController.java
@@ -1,6 +1,7 @@
 package kr.codesquad.secondhand.presentation;
 
 import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import kr.codesquad.secondhand.application.auth.AuthService;
 import kr.codesquad.secondhand.application.auth.TokenService;
@@ -12,6 +13,7 @@ import kr.codesquad.secondhand.presentation.dto.member.LoginResponse;
 import kr.codesquad.secondhand.presentation.dto.member.SignUpRequest;
 import kr.codesquad.secondhand.presentation.dto.token.AccessTokenResponse;
 import kr.codesquad.secondhand.presentation.dto.token.TokenRenewRequest;
+import kr.codesquad.secondhand.presentation.support.Auth;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -58,5 +60,12 @@ public class AuthController {
     @PostMapping("/token")
     public ApiResponse<AccessTokenResponse> renewAccessToken(@Valid @RequestBody TokenRenewRequest request) {
         return new ApiResponse<>(HttpStatus.OK.value(), tokenService.renewAccessToken(request.getRefreshToken()));
+    }
+
+    @ResponseStatus(value = HttpStatus.OK)
+    @PostMapping("/logout")
+    public ApiResponse<Void> logout(HttpServletRequest request, @Auth Long memberId) {
+        tokenService.logout(request, memberId);
+        return new ApiResponse<>(HttpStatus.OK.value());
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/presentation/dto/item/ItemResponse.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/dto/item/ItemResponse.java
@@ -12,7 +12,7 @@ public class ItemResponse {
     private String title;
     private String tradingRegion;
     private LocalDateTime createdAt;
-    private Integer price;
+    private Long price;
     private ItemStatus status;
     private int chatCount;
     private int wishCount;

--- a/src/main/java/kr/codesquad/secondhand/presentation/filter/JwtFilter.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/filter/JwtFilter.java
@@ -22,7 +22,7 @@ public class JwtFilter extends OncePerRequestFilter {
     private static final String BEARER = "bearer";
 
     private final AntPathMatcher pathMatcher = new AntPathMatcher();
-    private final List<String> excludeUrlPatterns = List.of("/api/auth/**");
+    private final List<String> excludeUrlPatterns = List.of("/api/auth/**/login", "/api/auth/**/signup");
 
     private final JwtProvider jwtProvider;
     private final AuthenticationContext authenticationContext;

--- a/src/main/java/kr/codesquad/secondhand/presentation/filter/JwtFilter.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/filter/JwtFilter.java
@@ -49,6 +49,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
         String token = extractJwt(request)
                 .orElseThrow(() -> new UnAuthorizedException(ErrorCode.INVALID_AUTH_HEADER));
+        jwtProvider.validBlackToken(token);
         jwtProvider.validateToken(token);
         authenticationContext.setMemberId(jwtProvider.extractClaims(token));
 

--- a/src/main/resources/application-redis.yml
+++ b/src/main/resources/application-redis.yml
@@ -1,0 +1,3 @@
+redis:
+    host: localhost
+    port: 6379

--- a/src/main/resources/application-redis.yml
+++ b/src/main/resources/application-redis.yml
@@ -1,3 +1,3 @@
 redis:
-    host: 127.0.0.1
+    host: localhost
     port: 6379

--- a/src/main/resources/application-redis.yml
+++ b/src/main/resources/application-redis.yml
@@ -1,3 +1,3 @@
 redis:
-    host: localhost
+    host: 127.0.0.1
     port: 6379

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -37,3 +37,7 @@ oauth2:
   provider:
     token-url: token-url
     user-info-url: user-info-url
+
+redis:
+  host: 127.0.0.1
+  port: 6379

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -39,5 +39,5 @@ oauth2:
     user-info-url: user-info-url
 
 redis:
-  host: 127.0.0.1
+  host: localhost
   port: 6379

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,11 +1,12 @@
 spring:
   profiles:
     active:
-      - prod
+      - local
     include:
       - oauth
       - secret
       - db
+      - redis
 custom:
   default-profile:
     https://e7.pngegg.com/pngimages/1000/665/png-clipart-computer-icons-profile-s-free-angle-sphere.png

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 spring:
   profiles:
     active:
-      - local
+      - prod
     include:
       - oauth
       - secret

--- a/src/main/resources/docker.yml
+++ b/src/main/resources/docker.yml
@@ -1,6 +1,6 @@
 version: '3'
 services:
-  mysql:  # 로컬 환경에서 동작시킬 DB
+  mysql: # 로컬 환경에서 동작시킬 DB
     image: mysql:8.0
     container_name: mysql-local
     ports:
@@ -26,5 +26,10 @@ services:
     command:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
+  redis:
+    image: redis
+    container_name: redis
+    ports:
+      - "6379:6379"
 
 # docker-compose -f docker.yml up -d

--- a/src/test/java/kr/codesquad/secondhand/RedisTemplateCreator.java
+++ b/src/test/java/kr/codesquad/secondhand/RedisTemplateCreator.java
@@ -1,0 +1,21 @@
+package kr.codesquad.secondhand;
+
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+public class RedisTemplateCreator {
+
+    private static RedisConnectionFactory getRedisConnectionFactory() {
+        return new LettuceConnectionFactory("localhost", 6379);
+    }
+
+    public static RedisTemplate<String, Object> getRedisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(getRedisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/src/test/java/kr/codesquad/secondhand/TokenCreator.java
+++ b/src/test/java/kr/codesquad/secondhand/TokenCreator.java
@@ -12,7 +12,10 @@ import java.util.Date;
 public class TokenCreator {
 
     private static final String secretKey = "2901ujr9021urf0u902hf021y90fh9c210hg093hg091h3g90h30gh901hg09h01";
-    private static final JwtProvider jwtProvider = new JwtProvider(new JwtProperties(secretKey, 10000, 100000));
+    private static final JwtProvider jwtProvider = new JwtProvider(
+            new JwtProperties(secretKey, 10000, 100000),
+            RedisTemplateCreator.getRedisTemplate()
+            );
 
     public static String createToken(Long payload) {
         return jwtProvider.createAccessToken(payload);

--- a/src/test/java/kr/codesquad/secondhand/infrastructure/RedisTemplateTest.java
+++ b/src/test/java/kr/codesquad/secondhand/infrastructure/RedisTemplateTest.java
@@ -1,0 +1,32 @@
+package kr.codesquad.secondhand.infrastructure;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+@SpringBootTest
+public class RedisTemplateTest {
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @DisplayName("Redis가 정상적으로 연결된다.")
+    @Test
+    void given_when_then() {
+        // given
+        ValueOperations<String, Object> valueOperations = redisTemplate.opsForValue();
+        String key = "accessToken";
+
+        // when
+        valueOperations.set(key, "logout");
+
+        // then
+        String value = String.valueOf(valueOperations.get(key));
+        assertThat(value).isEqualTo("logout");
+    }
+}

--- a/src/test/java/kr/codesquad/secondhand/infrastructure/jwt/JwtProviderTest.java
+++ b/src/test/java/kr/codesquad/secondhand/infrastructure/jwt/JwtProviderTest.java
@@ -1,5 +1,6 @@
 package kr.codesquad.secondhand.infrastructure.jwt;
 
+import kr.codesquad.secondhand.RedisTemplateCreator;
 import kr.codesquad.secondhand.TokenCreator;
 import kr.codesquad.secondhand.exception.ErrorCode;
 import kr.codesquad.secondhand.exception.UnAuthorizedException;
@@ -16,7 +17,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class JwtProviderTest {
 
     private final String secretKey = "2901ujr9021urf0u902hf021y90fh9c210hg093hg091h3g90h30gh901hg09h01";
-    private final JwtProvider jwtProvider = new JwtProvider(new JwtProperties(secretKey, 10000, 100000));
+    private final JwtProvider jwtProvider = new JwtProvider(
+            new JwtProperties(secretKey, 10000, 100000),
+            RedisTemplateCreator.getRedisTemplate());
 
     @DisplayName("회원의 PK가 payload로 주어지면 액세스 토큰이 생성되는데 성공한다.")
     @Test
@@ -65,5 +68,15 @@ class JwtProviderTest {
 
         // then
         assertThat(claims.get("memberId").toString()).isEqualTo("1");
+    }
+
+    @DisplayName("로그아웃한 엑세스토큰이 주어지면 에러를 발생시킨다.")
+    @Test
+    void given_when_then() {
+        // given
+
+        // when
+
+        // then
     }
 }


### PR DESCRIPTION
## Issues
- #51 

## What is this PR? 👓
로그아웃 기능 구현에 대한 pr입니다.

## Key changes 🔑
- redis를 사용해 로그아웃 요청 시 `accessToken`을 블랙리스트에 저장합니다.
- `JwtFilter`에서 유효한 토큰인지 확인하기 전에 `validBlackToken(accessToken)`을 호출해서 redis에 등록된 토큰인지 먼저 확인하도록 했습니다.

## To reviewers 👋
- 로컬환경에서 redis는 도커 컨테이너에 설치해서 사용했습니다. 배포환경에서는 도커 컴포즈 파일에만 설정정보를 추가해주면 될 것 같아요! 아래는 예시입니다!
```
version: '3'
    services:
        redis:
            image: redis
            container_name: redis
            ports:
                - "6379:6379"
```
- 로그아웃 메서드를 `AuthService`에 뒀는데 토큰을 삭제, 등록하는 작업이다보니 `TokenService`로 로직을 옮기고 `AuthService`에서 호출하는게 나을지 고민입니다!
- 테스트코드를 작성하려고 했는데 너무 어려워서.. 우선 redis 연결 테스트만 작성했습니다! 나머지 테스트 코드도 마저 작성할게요...!