### PR TITLE
회원가입시 여러 개의 주소를 받을 수 있도록 변경

### DIFF
--- a/src/main/java/kr/codesquad/secondhand/application/auth/ResidenceService.java
+++ b/src/main/java/kr/codesquad/secondhand/application/auth/ResidenceService.java
@@ -1,7 +1,6 @@
 package kr.codesquad.secondhand.application.auth;
 
 import kr.codesquad.secondhand.domain.member.Member;
-import kr.codesquad.secondhand.domain.residence.Residence;
 import kr.codesquad.secondhand.presentation.dto.member.SignUpRequest;
 import kr.codesquad.secondhand.repository.residence.ResidenceRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +15,7 @@ public class ResidenceService {
     private final ResidenceRepository residenceRepository;
 
     @Transactional
-    public Residence saveResidence(SignUpRequest request, Member member) {
-        return residenceRepository.save(request.toResidenceEntity(member));
+    public void saveResidence(SignUpRequest request, Member member) {
+        residenceRepository.saveAll(request.toResidenceEntities(member));
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/application/wishitem/WishItemService.java
+++ b/src/main/java/kr/codesquad/secondhand/application/wishitem/WishItemService.java
@@ -1,8 +1,8 @@
 package kr.codesquad.secondhand.application.wishitem;
 
-import kr.codesquad.secondhand.domain.WishItem;
 import kr.codesquad.secondhand.domain.item.Item;
 import kr.codesquad.secondhand.domain.member.Member;
+import kr.codesquad.secondhand.domain.wishitem.WishItem;
 import kr.codesquad.secondhand.repository.wishitem.WishItemRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/kr/codesquad/secondhand/domain/wishitem/WishItem.java
+++ b/src/main/java/kr/codesquad/secondhand/domain/wishitem/WishItem.java
@@ -1,4 +1,4 @@
-package kr.codesquad.secondhand.domain;
+package kr.codesquad.secondhand.domain.wishitem;
 
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -25,7 +25,7 @@ public class WishItem {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @JoinColumn(name = "memeber_id", nullable = false)
+    @JoinColumn(name = "member_id", nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
 

--- a/src/main/java/kr/codesquad/secondhand/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/codesquad/secondhand/exception/GlobalExceptionHandler.java
@@ -2,11 +2,19 @@ package kr.codesquad.secondhand.exception;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidException(MethodArgumentNotValidException e) {
+        String exMessage = e.getBindingResult().getFieldError().getDefaultMessage();
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(400, exMessage));
+    }
 
     @ExceptionHandler(BadRequestException.class)
     public ResponseEntity<ErrorResponse> handleBadRequestException(BadRequestException e) {

--- a/src/main/java/kr/codesquad/secondhand/presentation/AuthController.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/AuthController.java
@@ -44,11 +44,11 @@ public class AuthController {
 
     @ResponseStatus(value = HttpStatus.CREATED)
     @PostMapping(value = "/naver/signup", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ApiResponse<Void> signUp(@RequestPart @Valid SignUpRequest request,
+    public ApiResponse<Void> signUp(@RequestPart @Valid SignUpRequest signupData,
                                     @RequestParam Optional<String> code,
                                     @RequestParam Optional<String> state,
                                     @RequestPart Optional<MultipartFile> profile) {
-        authService.signUp(request,
+        authService.signUp(signupData,
                 code.orElseThrow(() -> new BadRequestException(ErrorCode.INVALID_PARAMETER)),
                 profile);
         return new ApiResponse<>(HttpStatus.CREATED.value());

--- a/src/main/java/kr/codesquad/secondhand/presentation/dto/item/ItemResponse.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/dto/item/ItemResponse.java
@@ -12,7 +12,7 @@ public class ItemResponse {
     private String title;
     private String tradingRegion;
     private LocalDateTime createdAt;
-    private Integer price;
+    private Long price;
     private ItemStatus status;
     private int chatCount;
     private int wishCount;

--- a/src/main/java/kr/codesquad/secondhand/presentation/dto/member/SignUpRequest.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/dto/member/SignUpRequest.java
@@ -1,5 +1,7 @@
 package kr.codesquad.secondhand.presentation.dto.member;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 import kr.codesquad.secondhand.domain.member.Member;
@@ -15,12 +17,12 @@ public class SignUpRequest {
     @NotBlank
     @Size(min = 2, max = 12, message = "아이디는 2자 ~ 12자여야 합니다.")
     private String loginId;
-    @NotBlank
-    private String addressName;
+    @Size(min = 1, max = 2, message = "주소는 최소 1개, 최대 2개까지 들어올 수 있습니다.")
+    private List<String> addressNames;
 
-    public SignUpRequest(String loginId, String addressName) {
+    public SignUpRequest(String loginId, List<String> addressNames) {
         this.loginId = loginId;
-        this.addressName = addressName;
+        this.addressNames = addressNames;
     }
 
     public Member toMemberEntity(UserProfile userProfile) {
@@ -31,10 +33,12 @@ public class SignUpRequest {
                 .build();
     }
 
-    public Residence toResidenceEntity(Member member) {
-        return Residence.builder()
-                .addressName(this.addressName)
-                .member(member)
-                .build();
+    public List<Residence> toResidenceEntities(Member member) {
+        return addressNames.stream()
+                .map(addressName -> Residence.builder()
+                        .addressName(addressName)
+                        .member(member)
+                        .build())
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/repository/wishitem/WishItemRepository.java
+++ b/src/main/java/kr/codesquad/secondhand/repository/wishitem/WishItemRepository.java
@@ -1,6 +1,6 @@
 package kr.codesquad.secondhand.repository.wishitem;
 
-import kr.codesquad.secondhand.domain.WishItem;
+import kr.codesquad.secondhand.domain.wishitem.WishItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -91,9 +91,9 @@ CREATE TABLE IF NOT EXISTS `second_hand`.`item_image`
 -- -----------------------------------------------------
 CREATE TABLE IF NOT EXISTS `second_hand`.`residence`
 (
-    `id`        BIGINT      NOT NULL AUTO_INCREMENT,
-    `addr_name` VARCHAR(50) NOT NULL COMMENT '읍/면/동 주소',
-    `member_id` BIGINT      NOT NULL,
+    `id`           BIGINT      NOT NULL AUTO_INCREMENT,
+    `address_name` VARCHAR(50) NOT NULL COMMENT '읍/면/동 주소',
+    `member_id`    BIGINT      NOT NULL,
     PRIMARY KEY (`id`)
 ) ENGINE = InnoDB;
 

--- a/src/test/java/kr/codesquad/secondhand/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/acceptance/AuthAcceptanceTest.java
@@ -12,6 +12,7 @@ import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import kr.codesquad.secondhand.domain.image.ImageFile;
 import kr.codesquad.secondhand.domain.member.UserProfile;
@@ -129,7 +130,7 @@ public class AuthAcceptanceTest extends AcceptanceTestSupport {
                     .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
                     .queryParam("code", "code")
                     .queryParam("state", "state")
-                    .multiPart("request", Map.of("loginId", "bruni", "addressName", "범박동"),
+                    .multiPart("signupData", Map.of("loginId", "bruni", "addressNames", List.of("범박동")),
                             MediaType.APPLICATION_JSON_VALUE)
                     .multiPart("profile", createFakeFile(),
                             MediaType.IMAGE_PNG_VALUE);
@@ -153,8 +154,8 @@ public class AuthAcceptanceTest extends AcceptanceTestSupport {
                     .given().log().all()
                     .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
                     .queryParam("state", "state")
-                    .multiPart("request",
-                            Map.of("loginId", "bruni", "addressName", "범박동"),
+                    .multiPart("signupData",
+                            Map.of("loginId", "bruni", "addressName", List.of("범박동")),
                             MediaType.APPLICATION_JSON_VALUE)
                     .multiPart("profile",
                             createFakeFile(),

--- a/src/test/java/kr/codesquad/secondhand/acceptance/WishItemAcceptanceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/acceptance/WishItemAcceptanceTest.java
@@ -3,9 +3,9 @@ package kr.codesquad.secondhand.acceptance;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.restassured.RestAssured;
-import kr.codesquad.secondhand.domain.WishItem;
 import kr.codesquad.secondhand.domain.item.Item;
 import kr.codesquad.secondhand.domain.member.Member;
+import kr.codesquad.secondhand.domain.wishitem.WishItem;
 import kr.codesquad.secondhand.fixture.FixtureFactory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/kr/codesquad/secondhand/application/wishitem/WishItemServiceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/application/wishitem/WishItemServiceTest.java
@@ -5,9 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.util.Optional;
 import kr.codesquad.secondhand.application.ApplicationTestSupport;
-import kr.codesquad.secondhand.domain.WishItem;
 import kr.codesquad.secondhand.domain.item.Item;
 import kr.codesquad.secondhand.domain.member.Member;
+import kr.codesquad.secondhand.domain.wishitem.WishItem;
 import kr.codesquad.secondhand.fixture.FixtureFactory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## Issues
- #55

## What is this PR? 👓
회원가입시 여러 개의 주소를 받을 수 있도록 변경한 PR입니다.

## Key changes 🔑
- `@Valid`애노테이션으로 검증할 때 해당 예외처리가 안되어 있어서 이를 구현했습니다.
- 회원가입때 여러 주소를 받을 수 있도록 변경했습니다.
  - 이와 관련된 테스트코드도 수정했습니다~!
  - postman에 key가 signupData로 되어 있길래 request -> signupData로 수정했습니다.

## To reviewers 👋
postman에 request -> signupData로 수정해주세요~!
