### PR TITLE
관심상품 목록 조회

### DIFF
--- a/src/main/java/kr/codesquad/secondhand/application/wishitem/WishItemService.java
+++ b/src/main/java/kr/codesquad/secondhand/application/wishitem/WishItemService.java
@@ -1,10 +1,16 @@
 package kr.codesquad.secondhand.application.wishitem;
 
+import java.util.List;
 import kr.codesquad.secondhand.domain.item.Item;
 import kr.codesquad.secondhand.domain.member.Member;
 import kr.codesquad.secondhand.domain.wishitem.WishItem;
+import kr.codesquad.secondhand.presentation.dto.CustomSlice;
+import kr.codesquad.secondhand.presentation.dto.item.ItemResponse;
+import kr.codesquad.secondhand.repository.category.CategoryRepository;
 import kr.codesquad.secondhand.repository.wishitem.WishItemRepository;
+import kr.codesquad.secondhand.repository.wishitem.querydsl.WishItemPaginationRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,6 +20,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class WishItemService {
 
     private final WishItemRepository wishItemRepository;
+    private final CategoryRepository categoryRepository;
+    private final WishItemPaginationRepository wishItemPaginationRepository;
 
     @Transactional
     public void registerWishItem(Long itemId, Long memberId) {
@@ -30,5 +38,24 @@ public class WishItemService {
     @Transactional
     public void removeWishItem(Long itemId, Long memberId) {
         wishItemRepository.deleteByItemIdAndMemberId(itemId, memberId);
+    }
+
+    public CustomSlice<ItemResponse> readAll(Long categoryId, Long cursor, int pageSize) {
+        String categoryName = categoryRepository.findNameById(categoryId).orElse(null);
+        Slice<ItemResponse> itemResponses = wishItemPaginationRepository.findAll(cursor, categoryName, pageSize);
+
+        List<ItemResponse> content = itemResponses.getContent();
+
+        Long nextCursor = setNextCursor(content, itemResponses.hasNext());
+
+        return new CustomSlice<>(content, nextCursor, itemResponses.hasNext());
+    }
+
+    private Long setNextCursor(List<ItemResponse> content, boolean hasNext) {
+        Long nextCursor = null;
+        if (hasNext) {
+            nextCursor = content.get(content.size() - 1).getItemId();
+        }
+        return nextCursor;
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/application/wishitem/WishItemService.java
+++ b/src/main/java/kr/codesquad/secondhand/application/wishitem/WishItemService.java
@@ -40,9 +40,10 @@ public class WishItemService {
         wishItemRepository.deleteByItemIdAndMemberId(itemId, memberId);
     }
 
-    public CustomSlice<ItemResponse> readAll(Long categoryId, Long cursor, int pageSize) {
+    public CustomSlice<ItemResponse> readAll(Long memberId, Long categoryId, Long cursor, int pageSize) {
         String categoryName = categoryRepository.findNameById(categoryId).orElse(null);
-        Slice<ItemResponse> itemResponses = wishItemPaginationRepository.findAll(cursor, categoryName, pageSize);
+        Slice<ItemResponse> itemResponses =
+                wishItemPaginationRepository.findAll(memberId, cursor, categoryName, pageSize);
 
         List<ItemResponse> content = itemResponses.getContent();
 

--- a/src/main/java/kr/codesquad/secondhand/domain/wishitem/WishItem.java
+++ b/src/main/java/kr/codesquad/secondhand/domain/wishitem/WishItem.java
@@ -1,6 +1,9 @@
 package kr.codesquad.secondhand.domain.wishitem;
 
+import java.time.LocalDateTime;
+import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -8,19 +11,23 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
-import kr.codesquad.secondhand.domain.AuditingFields;
 import kr.codesquad.secondhand.domain.item.Item;
 import kr.codesquad.secondhand.domain.member.Member;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "wish_item")
 @Entity
-public class WishItem extends AuditingFields {
+public class WishItem {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -33,6 +40,11 @@ public class WishItem extends AuditingFields {
     @JoinColumn(name = "item_id", nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
     private Item item;
+
+    @DateTimeFormat(iso = ISO.DATE_TIME)
+    @Column(nullable = false, updatable = false)
+    @CreatedDate
+    private LocalDateTime createdAt;
 
     @Builder
     private WishItem(Long id, Member member, Item item) {

--- a/src/main/java/kr/codesquad/secondhand/domain/wishitem/WishItem.java
+++ b/src/main/java/kr/codesquad/secondhand/domain/wishitem/WishItem.java
@@ -8,6 +8,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+import kr.codesquad.secondhand.domain.AuditingFields;
 import kr.codesquad.secondhand.domain.item.Item;
 import kr.codesquad.secondhand.domain.member.Member;
 import lombok.AccessLevel;
@@ -19,7 +20,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "wish_item")
 @Entity
-public class WishItem {
+public class WishItem extends AuditingFields {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/kr/codesquad/secondhand/presentation/WishItemController.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/WishItemController.java
@@ -39,7 +39,9 @@ public class WishItemController {
     @GetMapping
     public ApiResponse<CustomSlice<ItemResponse>> readAll(@RequestParam(required = false) Long categoryId,
                                                           @RequestParam(required = false) Long cursor,
-                                                          @RequestParam(required = false, defaultValue = "10") int pageSize) {
-        return new ApiResponse<>(HttpStatus.OK.value(), wishItemService.readAll(categoryId, cursor, pageSize));
+                                                          @RequestParam(required = false, defaultValue = "10") int pageSize,
+                                                          @Auth Long memberId) {
+        return new ApiResponse<>(HttpStatus.OK.value(),
+                wishItemService.readAll(memberId, categoryId, cursor, pageSize));
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/presentation/WishItemController.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/WishItemController.java
@@ -2,9 +2,12 @@ package kr.codesquad.secondhand.presentation;
 
 import kr.codesquad.secondhand.application.wishitem.WishItemService;
 import kr.codesquad.secondhand.presentation.dto.ApiResponse;
+import kr.codesquad.secondhand.presentation.dto.CustomSlice;
+import kr.codesquad.secondhand.presentation.dto.item.ItemResponse;
 import kr.codesquad.secondhand.presentation.support.Auth;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,5 +33,13 @@ public class WishItemController {
         }
         wishItemService.removeWishItem(itemId, memberId);
         return new ApiResponse<>(HttpStatus.OK.value());
+    }
+
+    @ResponseStatus(value = HttpStatus.OK)
+    @GetMapping
+    public ApiResponse<CustomSlice<ItemResponse>> readAll(@RequestParam(required = false) Long categoryId,
+                                                          @RequestParam(required = false) Long cursor,
+                                                          @RequestParam(required = false, defaultValue = "10") int pageSize) {
+        return new ApiResponse<>(HttpStatus.OK.value(), wishItemService.readAll(categoryId, cursor, pageSize));
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/repository/wishitem/querydsl/WishItemPaginationRepository.java
+++ b/src/main/java/kr/codesquad/secondhand/repository/wishitem/querydsl/WishItemPaginationRepository.java
@@ -1,0 +1,70 @@
+package kr.codesquad.secondhand.repository.wishitem.querydsl;
+
+import static kr.codesquad.secondhand.domain.item.QItem.item;
+import static kr.codesquad.secondhand.domain.wishitem.QWishItem.wishItem;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import kr.codesquad.secondhand.presentation.dto.item.ItemResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class WishItemPaginationRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public Slice<ItemResponse> findAll(Long wishItemId, String categoryName, int pageSize) {
+        List<ItemResponse> itemResponses = queryFactory.select(Projections.fields(ItemResponse.class,
+                        wishItem.item.id.as("itemId"),
+                        item.thumbnailUrl,
+                        item.title,
+                        item.tradingRegion,
+                        item.createdAt,
+                        item.price,
+                        item.status,
+                        item.chatCount,
+                        item.wishCount))
+                .from(wishItem)
+                .innerJoin(wishItem.item, item).on(wishItem.item.id.eq(item.id))
+                .where(lessThanId(wishItemId),
+                        eqCategoryName(categoryName))
+                .orderBy(wishItem.createdAt.desc())
+                .limit(pageSize + 1)    // 다음 요소가 있는지 확인하기 위해 +1개 만큼 더 가져온다.
+                .fetch();
+        return checkLastPage(pageSize, itemResponses);
+    }
+
+    private BooleanExpression lessThanId(Long wishItemId) {
+        if (wishItemId == null) {
+            return null;
+        }
+        return wishItem.id.lt(wishItemId);
+    }
+
+    private BooleanExpression eqCategoryName(String categoryName) {
+        if (categoryName == null) {
+            return null;
+        }
+        return item.categoryName.eq(categoryName);
+    }
+
+    private Slice<ItemResponse> checkLastPage(int pageSize, List<ItemResponse> results) {
+
+        boolean hasNext = false;
+
+        // 조회한 결과 개수가 요청한 페이지 사이즈보다 다음 페이지 존재, next = true
+        if (results.size() > pageSize) {
+            hasNext = true;
+            results.remove(pageSize);
+        }
+
+        return new SliceImpl<>(results, PageRequest.ofSize(pageSize), hasNext);
+    }
+}

--- a/src/main/java/kr/codesquad/secondhand/repository/wishitem/querydsl/WishItemPaginationRepository.java
+++ b/src/main/java/kr/codesquad/secondhand/repository/wishitem/querydsl/WishItemPaginationRepository.java
@@ -20,7 +20,7 @@ public class WishItemPaginationRepository {
 
     private final JPAQueryFactory queryFactory;
 
-    public Slice<ItemResponse> findAll(Long wishItemId, String categoryName, int pageSize) {
+    public Slice<ItemResponse> findAll(Long memberId, Long wishItemId, String categoryName, int pageSize) {
         List<ItemResponse> itemResponses = queryFactory.select(Projections.fields(ItemResponse.class,
                         wishItem.item.id.as("itemId"),
                         item.thumbnailUrl,
@@ -34,6 +34,7 @@ public class WishItemPaginationRepository {
                 .from(wishItem)
                 .innerJoin(wishItem.item, item).on(wishItem.item.id.eq(item.id))
                 .where(lessThanId(wishItemId),
+                        eqMemberId(memberId),
                         eqCategoryName(categoryName))
                 .orderBy(wishItem.createdAt.desc())
                 .limit(pageSize + 1)    // 다음 요소가 있는지 확인하기 위해 +1개 만큼 더 가져온다.
@@ -46,6 +47,13 @@ public class WishItemPaginationRepository {
             return null;
         }
         return wishItem.id.lt(wishItemId);
+    }
+
+    private BooleanExpression eqMemberId(Long memberId) {
+        if (memberId == null) {
+            return null;
+        }
+        return wishItem.member.id.eq(memberId);
     }
 
     private BooleanExpression eqCategoryName(String categoryName) {

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -131,9 +131,11 @@ CREATE TABLE IF NOT EXISTS `second_hand`.`chat_log`
 -- -----------------------------------------------------
 CREATE TABLE IF NOT EXISTS `second_hand`.`wish_item`
 (
-    `id`        BIGINT NOT NULL AUTO_INCREMENT,
-    `item_id`   BIGINT NOT NULL,
-    `member_id` BIGINT NOT NULL,
+    `id`         BIGINT    NOT NULL AUTO_INCREMENT,
+    `item_id`    BIGINT    NOT NULL,
+    `member_id`  BIGINT    NOT NULL,
+    `created_at` TIMESTAMP NOT NULL,
+    `updated_at` TIMESTAMP NOT NULL,
     PRIMARY KEY (`id`)
 ) ENGINE = InnoDB;
 

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -135,7 +135,6 @@ CREATE TABLE IF NOT EXISTS `second_hand`.`wish_item`
     `item_id`    BIGINT    NOT NULL,
     `member_id`  BIGINT    NOT NULL,
     `created_at` TIMESTAMP NOT NULL,
-    `updated_at` TIMESTAMP NOT NULL,
     PRIMARY KEY (`id`)
 ) ENGINE = InnoDB;
 

--- a/src/test/java/kr/codesquad/secondhand/acceptance/WishItemAcceptanceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/acceptance/WishItemAcceptanceTest.java
@@ -1,13 +1,18 @@
 package kr.codesquad.secondhand.acceptance;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import io.restassured.RestAssured;
+import io.restassured.path.json.JsonPath;
+import io.restassured.specification.RequestSpecification;
+import kr.codesquad.secondhand.domain.category.Category;
 import kr.codesquad.secondhand.domain.item.Item;
 import kr.codesquad.secondhand.domain.member.Member;
 import kr.codesquad.secondhand.domain.wishitem.WishItem;
 import kr.codesquad.secondhand.fixture.FixtureFactory;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 
@@ -61,5 +66,80 @@ public class WishItemAcceptanceTest extends AcceptanceTestSupport {
 
         // then
         assertThat(response.statusCode()).isEqualTo(200);
+    }
+
+    private void saveItemsAndWishItemsAndCategory(Member member) {
+        supportRepository.save(Category.builder()
+                .name("가전")
+                .imageUrl("url")
+                .build());
+        for (int i = 1; i <= 20; i++) {
+            Item item = supportRepository.save(FixtureFactory.createItem("선풍기 - " + i, "가전", member));
+            supportRepository.save(WishItem.builder()
+                    .item(item)
+                    .member(member)
+                    .build());
+        }
+    }
+
+    @DisplayName("관심 상품 목록을 조회할 때")
+    @Nested
+    class ReadAll {
+
+        @DisplayName("첫 번쨰 페이지를 조회하면 최근 등록한 관심 상품 순서로 관심 상품 목록이 조회된다.")
+        @Test
+        void given_whenReadAllWishItemsOfFirstPage_thenSuccess() {
+            // given
+            Member member = signup();
+            saveItemsAndWishItemsAndCategory(member);
+
+            var request = RestAssured
+                    .given().log().all()
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtProvider.createAccessToken(1L));
+
+            // when
+            var response = readAll(request);
+
+            // then
+            assertAll(
+                    () -> assertThat(response.getString("data.contents[0].title")).isEqualTo("선풍기 - 20"),
+                    () -> assertThat(response.getString("data.contents[9].title")).isEqualTo("선풍기 - 11"),
+                    () -> assertThat(response.getLong("data.paging.nextCursor")).isEqualTo(11L),
+                    () -> assertThat(response.getBoolean("data.paging.hasNext")).isTrue()
+            );
+        }
+
+        @DisplayName("마지막 페이지를 조회하면 최근 등록한 관심 상품 순서로 관심 상품 목록이 조회된다.")
+        @Test
+        void givenCategoryId_whenReadAllWishItemsOfLastPage_thenSuccess() {
+            // given
+            Member member = signup();
+            saveItemsAndWishItemsAndCategory(member);
+
+            var request = RestAssured
+                    .given().log().all()
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtProvider.createAccessToken(1L))
+                    .queryParam("cursor", 11L);
+
+            // when
+            var response = readAll(request);
+
+            // then
+            assertAll(
+                    () -> assertThat(response.getString("data.contents[0].title")).isEqualTo("선풍기 - 10"),
+                    () -> assertThat(response.getString("data.contents[9].title")).isEqualTo("선풍기 - 1"),
+                    () -> assertThat(response.getObject("data.paging.nextCursor", Long.class)).isNull(),
+                    () -> assertThat(response.getBoolean("data.paging.hasNext")).isFalse()
+            );
+        }
+
+        private JsonPath readAll(RequestSpecification request) {
+            return request
+                    .when()
+                    .get("/api/wishes")
+                    .then().log().all()
+                    .statusCode(200)
+                    .extract().response().jsonPath();
+        }
     }
 }

--- a/src/test/java/kr/codesquad/secondhand/application/wishitem/WishItemServiceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/application/wishitem/WishItemServiceTest.java
@@ -5,11 +5,15 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.util.Optional;
 import kr.codesquad.secondhand.application.ApplicationTestSupport;
+import kr.codesquad.secondhand.domain.category.Category;
 import kr.codesquad.secondhand.domain.item.Item;
 import kr.codesquad.secondhand.domain.member.Member;
 import kr.codesquad.secondhand.domain.wishitem.WishItem;
 import kr.codesquad.secondhand.fixture.FixtureFactory;
+import kr.codesquad.secondhand.presentation.dto.CustomSlice;
+import kr.codesquad.secondhand.presentation.dto.item.ItemResponse;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -53,5 +57,70 @@ class WishItemServiceTest extends ApplicationTestSupport {
         Optional<WishItem> wishItem = supportRepository.findById(WishItem.class, 1L);
 
         assertThat(wishItem).isNotPresent();
+    }
+
+    private Member signup() {
+        return supportRepository.save(FixtureFactory.createMember());
+    }
+
+    @DisplayName("관심 상품 목록을 조회할 때")
+    @Nested
+    class ReadAll {
+
+        @DisplayName("최근 관심상품으로 등록한 순서대로 상품이 조회된다.")
+        @Test
+        void given_whenReadAllWishItemsOfFirstPage_thenSuccess() {
+            // given
+            Member member = signup();
+            supportRepository.save(Category.builder()
+                    .name("가전")
+                    .imageUrl("url")
+                    .build());
+            for (int i = 1; i <= 20; i++) {
+                Item item = supportRepository.save(FixtureFactory.createItem("선풍기 - " + i, "가전", member));
+                supportRepository.save(WishItem.builder()
+                        .item(item)
+                        .member(member)
+                        .build());
+            }
+
+            // when
+            CustomSlice<ItemResponse> response = wishItemService.readAll(null, null, 10);
+
+            // then
+            assertAll(
+                    () -> assertThat(response.getContents()).hasSize(10),
+                    () -> assertThat(response.getPaging().getNextCursor()).isEqualTo(11L),
+                    () -> assertThat(response.getPaging().isHasNext()).isTrue()
+            );
+        }
+
+        @DisplayName("최근 관심상품으로 등록한 순서대로 상품이 조회된다.")
+        @Test
+        void given_whenReadAllWishItemsOfLastPage_thenSuccess() {
+            // given
+            Member member = signup();
+            supportRepository.save(Category.builder()
+                    .name("가전")
+                    .imageUrl("url")
+                    .build());
+            for (int i = 1; i <= 20; i++) {
+                Item item = supportRepository.save(FixtureFactory.createItem("선풍기 - " + i, "가전", member));
+                supportRepository.save(WishItem.builder()
+                        .item(item)
+                        .member(member)
+                        .build());
+            }
+
+            // when
+            CustomSlice<ItemResponse> response = wishItemService.readAll(null, 11L, 10);
+
+            // then
+            assertAll(
+                    () -> assertThat(response.getContents()).hasSize(10),
+                    () -> assertThat(response.getPaging().getNextCursor()).isNull(),
+                    () -> assertThat(response.getPaging().isHasNext()).isFalse()
+            );
+        }
     }
 }

--- a/src/test/java/kr/codesquad/secondhand/application/wishitem/WishItemServiceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/application/wishitem/WishItemServiceTest.java
@@ -85,7 +85,7 @@ class WishItemServiceTest extends ApplicationTestSupport {
             }
 
             // when
-            CustomSlice<ItemResponse> response = wishItemService.readAll(null, null, 10);
+            CustomSlice<ItemResponse> response = wishItemService.readAll(1L, null, null, 10);
 
             // then
             assertAll(
@@ -113,7 +113,7 @@ class WishItemServiceTest extends ApplicationTestSupport {
             }
 
             // when
-            CustomSlice<ItemResponse> response = wishItemService.readAll(null, 11L, 10);
+            CustomSlice<ItemResponse> response = wishItemService.readAll(1L, null, 11L, 10);
 
             // then
             assertAll(


### PR DESCRIPTION
## Issues
- #57 

## What is this PR? 👓
관심상품 목록을 조회하는 기능에 대한 PR입니다.

## Key changes 🔑
- `wish_item` 테이블에 `created_at` 컬럼 추가
  - 스키마에도 반영
- 관심상품 목록 조회
  - 페이징 (NO-OFFSET 방식)
  - 카테고리별 관심상품 목록 조회
- 테스트코드 작성 

## To reviewers 👋
`created_at` 컬럼을 추가한 이유는 관심상품 목록 페이지에 상품을 불러올 때 최근 등록한 관심상품 순으로 보여주기 위해서 `created_at`컬럼을 추가하게 되었습니다.