### PR TITLE
컨트롤러레이어가 아닌  서비스 레이어에서 예외처리하도록 수정

### DIFF
--- a/src/main/java/kr/codesquad/secondhand/application/item/ItemService.java
+++ b/src/main/java/kr/codesquad/secondhand/application/item/ItemService.java
@@ -6,6 +6,7 @@ import kr.codesquad.secondhand.application.image.ImageService;
 import kr.codesquad.secondhand.domain.item.Item;
 import kr.codesquad.secondhand.domain.itemimage.ItemImage;
 import kr.codesquad.secondhand.domain.member.Member;
+import kr.codesquad.secondhand.exception.BadRequestException;
 import kr.codesquad.secondhand.exception.ErrorCode;
 import kr.codesquad.secondhand.exception.ForbiddenException;
 import kr.codesquad.secondhand.exception.NotFoundException;
@@ -24,7 +25,6 @@ import kr.codesquad.secondhand.repository.wishitem.WishItemRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.scheduling.annotation.Async;
-import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -45,6 +45,9 @@ public class ItemService {
 
     @Transactional
     public void register(List<MultipartFile> images, ItemRegisterRequest request, Long sellerId) {
+        if (images == null) {
+            throw new BadRequestException(ErrorCode.INVALID_PARAMETER, "이미지는 최소 1개이상 들어와야 합니다.");
+        }
         List<String> itemImageUrls = imageService.uploadImages(images);
         String thumbnailUrl = itemImageUrls.get(0);
 

--- a/src/main/java/kr/codesquad/secondhand/config/WebConfig.java
+++ b/src/main/java/kr/codesquad/secondhand/config/WebConfig.java
@@ -2,6 +2,7 @@ package kr.codesquad.secondhand.config;
 
 import java.util.List;
 import kr.codesquad.secondhand.presentation.support.AuthArgumentResolver;
+import kr.codesquad.secondhand.presentation.support.NotNullParamArgumentResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
@@ -12,9 +13,11 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class WebConfig implements WebMvcConfigurer {
 
     private final AuthArgumentResolver authArgumentResolver;
+    private final NotNullParamArgumentResolver notNullParamArgumentResolver;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(authArgumentResolver);
+        resolvers.add(notNullParamArgumentResolver);
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/presentation/AuthController.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/AuthController.java
@@ -1,12 +1,9 @@
 package kr.codesquad.secondhand.presentation;
 
-import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import kr.codesquad.secondhand.application.auth.AuthService;
 import kr.codesquad.secondhand.application.auth.TokenService;
-import kr.codesquad.secondhand.exception.BadRequestException;
-import kr.codesquad.secondhand.exception.ErrorCode;
 import kr.codesquad.secondhand.presentation.dto.ApiResponse;
 import kr.codesquad.secondhand.presentation.dto.member.LoginRequest;
 import kr.codesquad.secondhand.presentation.dto.member.LoginResponse;
@@ -14,6 +11,7 @@ import kr.codesquad.secondhand.presentation.dto.member.SignUpRequest;
 import kr.codesquad.secondhand.presentation.dto.token.AccessTokenResponse;
 import kr.codesquad.secondhand.presentation.dto.token.TokenRenewRequest;
 import kr.codesquad.secondhand.presentation.support.Auth;
+import kr.codesquad.secondhand.presentation.support.NotNullParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -37,22 +35,18 @@ public class AuthController {
     @ResponseStatus(value = HttpStatus.OK)
     @PostMapping("/naver/login")
     public ApiResponse<LoginResponse> login(@RequestBody @Valid LoginRequest request,
-                                            @RequestParam Optional<String> code,
-                                            @RequestParam Optional<String> state) {
-        return new ApiResponse<>(HttpStatus.OK.value(),
-                authService.login(request,
-                        code.orElseThrow(() -> new BadRequestException(ErrorCode.INVALID_PARAMETER))));
+                                            @NotNullParam(message = "code 값은 반드시 들어와야 합니다.") String code,
+                                            @RequestParam(required = false) String state) {
+        return new ApiResponse<>(HttpStatus.OK.value(), authService.login(request, code));
     }
 
     @ResponseStatus(value = HttpStatus.CREATED)
     @PostMapping(value = "/naver/signup", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<Void> signUp(@RequestPart @Valid SignUpRequest signupData,
-                                    @RequestParam Optional<String> code,
-                                    @RequestParam Optional<String> state,
-                                    @RequestPart Optional<MultipartFile> profile) {
-        authService.signUp(signupData,
-                code.orElseThrow(() -> new BadRequestException(ErrorCode.INVALID_PARAMETER)),
-                profile);
+                                    @NotNullParam(message = "code 값은 반드시 들어와야 합니다.") String code,
+                                    @RequestParam(required = false) String state,
+                                    @RequestPart(required = false) MultipartFile profile) {
+        authService.signUp(signupData, code, profile);
         return new ApiResponse<>(HttpStatus.CREATED.value());
     }
 

--- a/src/main/java/kr/codesquad/secondhand/presentation/ItemController.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/ItemController.java
@@ -1,11 +1,8 @@
 package kr.codesquad.secondhand.presentation;
 
 import java.util.List;
-import java.util.Optional;
 import javax.validation.Valid;
 import kr.codesquad.secondhand.application.item.ItemService;
-import kr.codesquad.secondhand.exception.BadRequestException;
-import kr.codesquad.secondhand.exception.ErrorCode;
 import kr.codesquad.secondhand.presentation.dto.ApiResponse;
 import kr.codesquad.secondhand.presentation.dto.CustomSlice;
 import kr.codesquad.secondhand.presentation.dto.item.ItemDetailResponse;
@@ -14,6 +11,7 @@ import kr.codesquad.secondhand.presentation.dto.item.ItemResponse;
 import kr.codesquad.secondhand.presentation.dto.item.ItemStatusRequest;
 import kr.codesquad.secondhand.presentation.dto.item.ItemUpdateRequest;
 import kr.codesquad.secondhand.presentation.support.Auth;
+import kr.codesquad.secondhand.presentation.support.NotNullParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -40,14 +38,10 @@ public class ItemController {
 
     @ResponseStatus(value = HttpStatus.CREATED)
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ApiResponse<Void> registerItem(@RequestPart Optional<List<MultipartFile>> images,
+    public ApiResponse<Void> registerItem(@RequestPart(required = false) List<MultipartFile> images,
                                           @Valid @RequestPart ItemRegisterRequest item,
                                           @Auth Long memberId) {
-        itemService.register(
-                images.orElseThrow(() -> new BadRequestException(
-                        ErrorCode.INVALID_PARAMETER, "이미지는 최소 1개이상 들어와야 합니다.")),
-                item,
-                memberId);
+        itemService.register(images, item, memberId);
         return new ApiResponse<>(HttpStatus.CREATED.value());
     }
 
@@ -56,11 +50,9 @@ public class ItemController {
     public ApiResponse<CustomSlice<ItemResponse>> readAll(
             @RequestParam(required = false) Long cursor,
             @RequestParam(required = false) Long categoryId,
-            @RequestParam Optional<String> region,
+            @NotNullParam(message = "상품 조회시 지역정보는 반드시 들어와야 합니다.") String region,
             @RequestParam(required = false, defaultValue = "10") int size) {
-        String regionName = region
-                .orElseThrow(() -> new BadRequestException(ErrorCode.INVALID_PARAMETER, "상품 조회시 지역정보는 반드시 들어와야 합니다."));
-        return new ApiResponse<>(HttpStatus.OK.value(), itemService.readAll(cursor, categoryId, regionName, size));
+        return new ApiResponse<>(HttpStatus.OK.value(), itemService.readAll(cursor, categoryId, region, size));
     }
 
     @ResponseStatus(value = HttpStatus.OK)
@@ -72,11 +64,11 @@ public class ItemController {
 
     @ResponseStatus(value = HttpStatus.OK)
     @PatchMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ApiResponse<Void> updateItem(@RequestPart Optional<List<MultipartFile>> images,
+    public ApiResponse<Void> updateItem(@RequestPart(required = false) List<MultipartFile> images,
                                         @Valid @RequestPart ItemUpdateRequest item,
                                         @PathVariable Long itemId,
                                         @Auth Long memberId) {
-        itemService.update(images.orElse(null), item, itemId, memberId);
+        itemService.update(images, item, itemId, memberId);
         return new ApiResponse<>(HttpStatus.OK.value());
     }
 

--- a/src/main/java/kr/codesquad/secondhand/presentation/support/NotNullParam.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/support/NotNullParam.java
@@ -1,0 +1,15 @@
+package kr.codesquad.secondhand.presentation.support;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface NotNullParam {
+
+    String key() default "";
+
+    String message();
+}

--- a/src/main/java/kr/codesquad/secondhand/presentation/support/NotNullParamArgumentResolver.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/support/NotNullParamArgumentResolver.java
@@ -1,0 +1,36 @@
+package kr.codesquad.secondhand.presentation.support;
+
+import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
+import kr.codesquad.secondhand.exception.BadRequestException;
+import kr.codesquad.secondhand.exception.ErrorCode;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class NotNullParamArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(NotNullParam.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        NotNullParam annotation = parameter.getParameterAnnotation(NotNullParam.class);
+        String queryParamKey = annotation.key();
+        if (!StringUtils.hasText(queryParamKey)) {
+            queryParamKey = parameter.getParameterName();
+        }
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+
+        return Optional.ofNullable(request.getParameter(queryParamKey))
+                .orElseThrow(() -> new BadRequestException(ErrorCode.INVALID_PARAMETER, annotation.message()));
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -6,7 +6,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: validate
     properties:
       hibernate:
         show_sql: true

--- a/src/test/java/kr/codesquad/secondhand/TestContainer.java
+++ b/src/test/java/kr/codesquad/secondhand/TestContainer.java
@@ -3,7 +3,6 @@ package kr.codesquad.secondhand;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
 public abstract class TestContainer {
@@ -11,14 +10,8 @@ public abstract class TestContainer {
     static final GenericContainer redis = new GenericContainer(DockerImageName.parse("redis"))
             .withExposedPorts(6379);
 
-    static final MySQLContainer mySQLContainer = new MySQLContainer(DockerImageName.parse("mysql:8.0.34"))
-            .withDatabaseName("second_hand")
-            .withUsername("root")
-            .withPassword("root");
-
     static {
         redis.start();
-        mySQLContainer.start();
     }
 
     @DynamicPropertySource

--- a/src/test/java/kr/codesquad/secondhand/application/item/ItemServiceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/application/item/ItemServiceTest.java
@@ -177,6 +177,28 @@ class ItemServiceTest extends ApplicationTestSupport {
         return supportRepository.save(FixtureFactory.createMember());
     }
 
+    @DisplayName("아이템을 삭제 요청 시 아이템과 이미지를 삭제한다.")
+    @Test
+    void given_whenDeleteItem_thenSuccess() throws InterruptedException {
+        // given
+        given(s3Uploader.uploadImageFiles(anyList())).willReturn(List.of("url1", "url2", "url3"));
+        signup();
+        itemService.register(createFakeImage(), FixtureFactory.createItemRegisterRequest(), 1L);
+
+        // when
+        itemService.delete(1L, 1L);
+        Thread.sleep(1000); // 비동기 로직을 위해 지연
+
+        // then
+        Optional<Item> item = supportRepository.findById(Item.class, 1L);
+        List<ItemImage> images = supportRepository.findAll(ItemImage.class);
+
+        assertAll(
+                () -> assertThat(item).isNotPresent(),
+                () -> assertThat(images).isEmpty()
+        );
+    }
+
     @DisplayName("상품 전체 목록을 조회할 때")
     @Nested
     class ReadAll {
@@ -251,26 +273,5 @@ class ItemServiceTest extends ApplicationTestSupport {
                     () -> assertThat(response.getContents().get(7).getTitle()).isEqualTo("맛있는 거 - 3")
             );
         }
-    }
-
-    @DisplayName("아이템을 삭제 요청 시 아이템과 이미지를 삭제한다.")
-    @Test
-    void given_whenDeleteItem_thenSuccess() {
-        // given
-        given(s3Uploader.uploadImageFiles(anyList())).willReturn(List.of("url1", "url2", "url3"));
-        signup();
-        itemService.register(createFakeImage(), FixtureFactory.createItemRegisterRequest(), 1L);
-
-        // when
-        itemService.delete(1L, 1L);
-
-        // then
-        Optional<Item> item = supportRepository.findById(Item.class, 1L);
-        List<ItemImage> images = supportRepository.findAll(ItemImage.class);
-
-        assertAll(
-                () -> assertThat(item).isNotPresent(),
-                () -> assertThat(images).isEmpty()
-        );
     }
 }


### PR DESCRIPTION
## Issues
- #70 

## What is this PR? 👓
컨트롤러레이어가 아닌  서비스 레이어에서 예외처리하도록 수정한 PR입니다.

## Key changes 🔑
- `@NotNullParam`을 이용해서 요청이 들어온 uri의 쿼리 파라미터를 파싱했습니다.
  - 검증하는 resolver를 등록하여 resolver에서 예외를 던지도록 수정했습니다.
  - 이렇게 변경하면서 `Optional`을 사용하지 않고 일관되게 `required = false`를 가져가게 되었습니다.
- 상품 삭제시 비동기 메서드로 인해 테스트가 통과되지 않는 문제를 해결했습니다.
  - 1초정도 테스트 메서드를 지연시켜 해결했습니다.
- 테스트 컨테이너 수정
  - mySQLContainer.start()를 하지 않아도 컨테이너가 올라가는 것을 확인해 관련 메서드를 제거했습니다.
  - 이유에 대해서는 아직 잘 모르겠어서 찾아보겠습니다!

## To reviewers 👋
- `@NotNullParam` 사용법을 알아주세요!
- 서비스에서 if (param != null) 을 매번 하기 싫어서 위와 같이 만들었는데 더 좋은 방법이 있는지는 모르겠습니다ㅠ