### PR TITLE
거주지역 등록/삭제

### DIFF
--- a/src/main/java/kr/codesquad/secondhand/application/auth/AuthService.java
+++ b/src/main/java/kr/codesquad/secondhand/application/auth/AuthService.java
@@ -67,7 +67,7 @@ public class AuthService {
             userProfile.changeProfileUrl(profileUrl);
         }
         Member savedMember = saveMember(request, userProfile);
-        residenceService.saveResidence(request, savedMember);
+        residenceService.saveResidence(request.getAddressNames(), savedMember);
     }
 
     private void verifyDuplicated(SignUpRequest request) {

--- a/src/main/java/kr/codesquad/secondhand/application/residence/ResidenceService.java
+++ b/src/main/java/kr/codesquad/secondhand/application/residence/ResidenceService.java
@@ -74,4 +74,13 @@ public class ResidenceService {
 
         residenceRepository.save(Residence.from(memberId, region.getId(), addressName));
     }
+
+    @Transactional
+    public void remove(String addressName, Long memberId) {
+        if (residenceRepository.countByMemberId(memberId) <= MEMBER_HAS_RESIDENCE_MIN_COUNT) {
+            throw new BadRequestException(ErrorCode.INVALID_REQUEST, "사용자의 거주 지역은 최소 한 개는 있어야 합니다.");
+        }
+
+        residenceRepository.deleteByAddressName(addressName);
+    }
 }

--- a/src/main/java/kr/codesquad/secondhand/application/residence/ResidenceService.java
+++ b/src/main/java/kr/codesquad/secondhand/application/residence/ResidenceService.java
@@ -5,8 +5,10 @@ import java.util.List;
 import kr.codesquad.secondhand.domain.member.Member;
 import kr.codesquad.secondhand.domain.residence.Region;
 import kr.codesquad.secondhand.domain.residence.Residence;
+import kr.codesquad.secondhand.exception.BadRequestException;
+import kr.codesquad.secondhand.exception.ErrorCode;
+import kr.codesquad.secondhand.exception.NotFoundException;
 import kr.codesquad.secondhand.presentation.dto.CustomSlice;
-import kr.codesquad.secondhand.presentation.dto.member.SignUpRequest;
 import kr.codesquad.secondhand.presentation.dto.residence.RegionResponse;
 import kr.codesquad.secondhand.repository.residence.RegionRepository;
 import kr.codesquad.secondhand.repository.residence.ResidenceRepository;
@@ -21,15 +23,17 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class ResidenceService {
 
+    private static final int MEMBER_HAS_RESIDENCE_MIN_COUNT = 1;
+    private static final int MEMBER_HAS_RESIDENCE_MAX_COUNT = 2;
+
     private final RegionPaginationRepository regionPaginationRepository;
     private final RegionRepository regionRepository;
     private final ResidenceRepository residenceRepository;
 
     @Transactional
-    public void saveResidence(SignUpRequest request, Member member) {
-        List<Long> regionIds = regionRepository.findAllIdsById(request.getAddressNames());
-        List<String> addressNames = request.getAddressNames();
-        
+    public void saveResidence(List<String> addressNames, Member member) {
+        List<Long> regionIds = regionRepository.findAllIdsById(addressNames);
+
         List<Residence> residences = new ArrayList<>();
         for (int i = 0; i < regionIds.size(); i++) {
             residences.add(Residence.builder()
@@ -57,5 +61,17 @@ public class ResidenceService {
             nextCursor = content.get(content.size() - 1).getAddressId();
         }
         return nextCursor;
+    }
+
+    @Transactional
+    public void register(String addressName, Long memberId) {
+        if (residenceRepository.countByMemberId(memberId) >= MEMBER_HAS_RESIDENCE_MAX_COUNT) {
+            throw new BadRequestException(ErrorCode.INVALID_REQUEST, "사용자의 거주 지역은 최대 두 개까지 설정 가능합니다.");
+        }
+
+        Region region = regionRepository.findByAddressName(addressName)
+                .orElseThrow(() -> NotFoundException.regionNotFound(ErrorCode.NOT_FOUND, addressName));
+
+        residenceRepository.save(Residence.from(memberId, region.getId(), addressName));
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/domain/residence/Residence.java
+++ b/src/main/java/kr/codesquad/secondhand/domain/residence/Residence.java
@@ -43,4 +43,16 @@ public class Residence {
         this.member = member;
         this.region = region;
     }
+
+    public static Residence from(Long memberId, Long regionId, String addressName) {
+        return Residence.builder()
+                .addressName(addressName)
+                .member(Member.builder()
+                        .id(memberId)
+                        .build())
+                .region(Region.builder()
+                        .id(regionId)
+                        .build())
+                .build();
+    }
 }

--- a/src/main/java/kr/codesquad/secondhand/exception/NotFoundException.java
+++ b/src/main/java/kr/codesquad/secondhand/exception/NotFoundException.java
@@ -3,6 +3,7 @@ package kr.codesquad.secondhand.exception;
 public class NotFoundException extends SecondHandException {
 
     private static final String ITEM_NOT_FOUND_MESSAGE_FORMAT = "%s 번호의 아이템을 찾을 수 없습니다.";
+    private static final String REGION_NOT_FOUND_MESSAGE_FORMAT = "%s을 가진 지역을 찾을 수 없습니다.";
 
     public NotFoundException(ErrorCode errorCode) {
         super(errorCode);
@@ -14,5 +15,9 @@ public class NotFoundException extends SecondHandException {
 
     public static NotFoundException itemNotFound(ErrorCode errorCode, Long itemId) {
         return new NotFoundException(errorCode, String.format(ITEM_NOT_FOUND_MESSAGE_FORMAT, itemId));
+    }
+
+    public static NotFoundException regionNotFound(ErrorCode errorCode, String addressName) {
+        return new NotFoundException(errorCode, String.format(REGION_NOT_FOUND_MESSAGE_FORMAT, addressName));
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/presentation/ResidenceController.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/ResidenceController.java
@@ -9,6 +9,7 @@ import kr.codesquad.secondhand.presentation.dto.residence.ResidenceRequest;
 import kr.codesquad.secondhand.presentation.support.Auth;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -34,6 +35,13 @@ public class ResidenceController {
     public ApiResponse<Void> registerResidence(@Valid @RequestBody ResidenceRequest request,
                                                @Auth Long memberId) {
         residenceService.register(request.getAddress(), memberId);
+        return new ApiResponse<>(HttpStatus.OK.value());
+    }
+
+    @DeleteMapping
+    public ApiResponse<Void> removeResidence(@Valid @RequestBody ResidenceRequest request,
+                                             @Auth Long memberId) {
+        residenceService.remove(request.getAddress(), memberId);
         return new ApiResponse<>(HttpStatus.OK.value());
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/presentation/ResidenceController.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/ResidenceController.java
@@ -1,12 +1,17 @@
 package kr.codesquad.secondhand.presentation;
 
+import javax.validation.Valid;
 import kr.codesquad.secondhand.application.residence.ResidenceService;
 import kr.codesquad.secondhand.presentation.dto.ApiResponse;
 import kr.codesquad.secondhand.presentation.dto.CustomSlice;
 import kr.codesquad.secondhand.presentation.dto.residence.RegionResponse;
+import kr.codesquad.secondhand.presentation.dto.residence.ResidenceRequest;
+import kr.codesquad.secondhand.presentation.support.Auth;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,5 +28,12 @@ public class ResidenceController {
                                                                    @RequestParam(required = false, defaultValue = "10") int size,
                                                                    @RequestParam(required = false) String region) {
         return new ApiResponse<>(HttpStatus.OK.value(), residenceService.readAllRegion(cursor, size, region));
+    }
+
+    @PostMapping
+    public ApiResponse<Void> registerResidence(@Valid @RequestBody ResidenceRequest request,
+                                               @Auth Long memberId) {
+        residenceService.register(request.getAddress(), memberId);
+        return new ApiResponse<>(HttpStatus.OK.value());
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/presentation/dto/residence/ResidenceRequest.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/dto/residence/ResidenceRequest.java
@@ -1,0 +1,16 @@
+package kr.codesquad.secondhand.presentation.dto.residence;
+
+import javax.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ResidenceRequest {
+
+    @NotBlank(message = "지역의 전체 이름은 들어와야합니다.")
+    private String fullAddress;
+
+    @NotBlank(message = "읍/면/동 이름은 들어와야 합니다.")
+    private String address;
+}

--- a/src/main/java/kr/codesquad/secondhand/presentation/filter/JwtFilter.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/filter/JwtFilter.java
@@ -11,17 +11,16 @@ import kr.codesquad.secondhand.exception.UnAuthorizedException;
 import kr.codesquad.secondhand.infrastructure.jwt.JwtExtractor;
 import kr.codesquad.secondhand.infrastructure.jwt.JwtProvider;
 import kr.codesquad.secondhand.presentation.support.AuthenticationContext;
+import org.springframework.http.HttpMethod;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 public class JwtFilter extends OncePerRequestFilter {
 
-    private static final String BEARER = "bearer";
-
     private final AntPathMatcher pathMatcher = new AntPathMatcher();
     private final List<String> excludeUrlPatterns =
-            List.of("/api/auth/**/login", "/api/auth/**/signup", "/api/regions/**");
+            List.of("/api/auth/**/login", "/api/auth/**/signup");
 
     private final JwtProvider jwtProvider;
     private final AuthenticationContext authenticationContext;
@@ -33,6 +32,11 @@ public class JwtFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
+        HttpMethod method = HttpMethod.resolve(request.getMethod());
+        if (method == HttpMethod.GET && request.getRequestURI().matches("/api/regions/*")) {
+            return true;
+        }
+
         return excludeUrlPatterns.stream()
                 .anyMatch(pattern -> pathMatcher.match(pattern, request.getRequestURI()));
     }

--- a/src/main/java/kr/codesquad/secondhand/repository/residence/RegionRepository.java
+++ b/src/main/java/kr/codesquad/secondhand/repository/residence/RegionRepository.java
@@ -1,6 +1,7 @@
 package kr.codesquad.secondhand.repository.residence;
 
 import java.util.List;
+import java.util.Optional;
 import kr.codesquad.secondhand.domain.residence.Region;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -10,4 +11,6 @@ public interface RegionRepository extends JpaRepository<Region, Long> {
 
     @Query("SELECT region.id FROM Region region WHERE region.addressName IN (:addressNames)")
     List<Long> findAllIdsById(@Param("addressNames") List<String> addressNames);
+
+    Optional<Region> findByAddressName(String addressName);
 }

--- a/src/main/java/kr/codesquad/secondhand/repository/residence/ResidenceRepository.java
+++ b/src/main/java/kr/codesquad/secondhand/repository/residence/ResidenceRepository.java
@@ -4,4 +4,6 @@ import kr.codesquad.secondhand.domain.residence.Residence;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ResidenceRepository extends JpaRepository<Residence, Long> {
+
+    int countByMemberId(Long memberId);
 }

--- a/src/main/java/kr/codesquad/secondhand/repository/residence/ResidenceRepository.java
+++ b/src/main/java/kr/codesquad/secondhand/repository/residence/ResidenceRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ResidenceRepository extends JpaRepository<Residence, Long> {
 
     int countByMemberId(Long memberId);
+
+    void deleteByAddressName(String addressName);
 }

--- a/src/test/java/kr/codesquad/secondhand/acceptance/ResidenceAcceptanceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/acceptance/ResidenceAcceptanceTest.java
@@ -4,10 +4,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+import java.util.Map;
+import kr.codesquad.secondhand.domain.member.Member;
 import kr.codesquad.secondhand.domain.residence.Region;
+import kr.codesquad.secondhand.domain.residence.Residence;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 
 public class ResidenceAcceptanceTest extends AcceptanceTestSupport {
 
@@ -74,6 +82,71 @@ public class ResidenceAcceptanceTest extends AcceptanceTestSupport {
                     () -> assertThat(response.getBoolean("data.paging.hasNext")).isFalse(),
                     () -> assertThat(response.getObject("data.paging.nextCursor", Long.class)).isNull()
             );
+        }
+    }
+
+    @DisplayName("사용자의 거주 지역을 추가할 때")
+    @Nested
+    class Register {
+
+        @DisplayName("읍면동 주소가 주어지면 등록에 성공한다.")
+        @Test
+        void givenAddressName_whenRegisterResidence_thenSuccess() {
+            // given
+            Member member = signup();
+            supportRepository.save(Region.builder()
+                    .fullAddressName("경기도 부천시 범안동")
+                    .addressName("범안동")
+                    .build());
+
+            var request = RestAssured
+                    .given().log().all()
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtProvider.createAccessToken(member.getId()))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(Map.of("fullAddress", "경기도 부천시 범안동", "address", "범안동"));
+
+            // when
+            var response = registerResidence(request);
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(200);
+        }
+
+        @DisplayName("사용자가 이미 두 개의 거주지역을 가지고 있으면 400응답을 받는다.")
+        @Test
+        void givenAlreadyHasTwoResidenceMember_whenRegisterResidence_thenResponse400() {
+            // given
+            Member member = signup();
+            Region beoman = supportRepository.save(Region.builder()
+                    .fullAddressName("경기도 부천시 범안동")
+                    .addressName("범안동")
+                    .build());
+            Region okgil = supportRepository.save(Region.builder()
+                    .fullAddressName("경기도 부천시 옥길동")
+                    .addressName("옥길동")
+                    .build());
+            supportRepository.save(Residence.from(member.getId(), beoman.getId(), "범안동"));
+            supportRepository.save(Residence.from(member.getId(), okgil.getId(), "옥길동"));
+
+            var request = RestAssured
+                    .given().log().all()
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtProvider.createAccessToken(member.getId()))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(Map.of("fullAddress", "경기도 부천시 오류동", "address", "오류동"));
+
+            // when
+            var response = registerResidence(request);
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(400);
+        }
+
+        private ExtractableResponse<Response> registerResidence(RequestSpecification request) {
+            return request
+                    .when()
+                    .post("/api/regions")
+                    .then().log().all()
+                    .extract();
         }
     }
 }

--- a/src/test/java/kr/codesquad/secondhand/application/residence/ResidenceServiceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/application/residence/ResidenceServiceTest.java
@@ -87,7 +87,7 @@ class ResidenceServiceTest extends ApplicationTestSupport {
         void givenAddressName_whenRegisterResidence_thenSuccess() {
             // given
             Member member = supportRepository.save(FixtureFactory.createMember());
-            Region region = supportRepository.save(Region.builder()
+            supportRepository.save(Region.builder()
                     .fullAddressName("경기도 부천시 범박동")
                     .addressName("범박동")
                     .build());
@@ -114,6 +114,49 @@ class ResidenceServiceTest extends ApplicationTestSupport {
 
             // when & then
             assertThatThrownBy(() -> residenceService.register("괴안동", member.getId()))
+                    .isInstanceOf(BadRequestException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.INVALID_REQUEST);
+        }
+    }
+
+    @DisplayName("사용자의 거주 지역을 삭제할 때")
+    @Nested
+    class Remove {
+
+        @DisplayName("읍면동 주소가 주어지면 삭제에 성공한다.")
+        @Test
+        void givenAddressName_whenRemoveResidence_thenSuccess() {
+            // given
+            Member member = supportRepository.save(FixtureFactory.createMember());
+            Region beombak = supportRepository.save(Region.builder()
+                    .fullAddressName("경기도 부천시 범박동")
+                    .addressName("범박동")
+                    .build());
+            Region okgil = supportRepository.save(Region.builder()
+                    .fullAddressName("경기도 부천시 옥길동")
+                    .addressName("옥길동")
+                    .build());
+            supportRepository.save(Residence.from(member.getId(), beombak.getId(), "범박동"));
+            supportRepository.save(Residence.from(member.getId(), okgil.getId(), "옥길동"));
+
+            // when & then
+            assertThatCode(() -> residenceService.remove("범박동", member.getId()))
+                    .doesNotThrowAnyException();
+        }
+
+        @DisplayName("거주 지역을 한 곳만 가지고 있는 회원이 주어지면 예외를 던진다.")
+        @Test
+        void givenMemberWhoHasOnlyOneResidence_whenRemoveResidence_thenThrowsException() {
+            // given
+            Member member = supportRepository.save(FixtureFactory.createMember());
+            Region beombak = supportRepository.save(Region.builder()
+                    .fullAddressName("경기도 부천시 범박동")
+                    .addressName("범박동")
+                    .build());
+            supportRepository.save(Residence.from(member.getId(), beombak.getId(), "범박동"));
+
+            // when & then
+            assertThatThrownBy(() -> residenceService.remove("범박동", member.getId()))
                     .isInstanceOf(BadRequestException.class)
                     .extracting("errorCode").isEqualTo(ErrorCode.INVALID_REQUEST);
         }

--- a/src/test/java/kr/codesquad/secondhand/application/residence/ResidenceServiceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/application/residence/ResidenceServiceTest.java
@@ -1,10 +1,17 @@
 package kr.codesquad.secondhand.application.residence;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import kr.codesquad.secondhand.application.ApplicationTestSupport;
+import kr.codesquad.secondhand.domain.member.Member;
 import kr.codesquad.secondhand.domain.residence.Region;
+import kr.codesquad.secondhand.domain.residence.Residence;
+import kr.codesquad.secondhand.exception.BadRequestException;
+import kr.codesquad.secondhand.exception.ErrorCode;
+import kr.codesquad.secondhand.fixture.FixtureFactory;
 import kr.codesquad.secondhand.presentation.dto.CustomSlice;
 import kr.codesquad.secondhand.presentation.dto.residence.RegionResponse;
 import org.junit.jupiter.api.DisplayName;
@@ -68,6 +75,47 @@ class ResidenceServiceTest extends ApplicationTestSupport {
                     () -> assertThat(response.getPaging().isHasNext()).isFalse(),
                     () -> assertThat(response.getPaging().getNextCursor()).isNull()
             );
+        }
+    }
+
+    @DisplayName("사용자의 거주 지역을 추가할 때")
+    @Nested
+    class Register {
+
+        @DisplayName("읍면동 주소가 주어지면 성공한다.")
+        @Test
+        void givenAddressName_whenRegisterResidence_thenSuccess() {
+            // given
+            Member member = supportRepository.save(FixtureFactory.createMember());
+            Region region = supportRepository.save(Region.builder()
+                    .fullAddressName("경기도 부천시 범박동")
+                    .addressName("범박동")
+                    .build());
+
+            // when & then
+            assertThatCode(() -> residenceService.register("범박동", member.getId())).doesNotThrowAnyException();
+        }
+
+        @DisplayName("사용자가 이미 두 개의 거주지역을 가지고 있으면 예외를 던진다.")
+        @Test
+        void givenAlreadyHasTwoResidenceMember_whenRegisterResidence_thenThrowsException() {
+            // given
+            Member member = supportRepository.save(FixtureFactory.createMember());
+            Region beombak = supportRepository.save(Region.builder()
+                    .fullAddressName("경기도 부천시 범박동")
+                    .addressName("범박동")
+                    .build());
+            Region okgil = supportRepository.save(Region.builder()
+                    .fullAddressName("경기도 부천시 옥길동")
+                    .addressName("옥길동")
+                    .build());
+            supportRepository.save(Residence.from(member.getId(), beombak.getId(), "범박동"));
+            supportRepository.save(Residence.from(member.getId(), okgil.getId(), "옥길동"));
+
+            // when & then
+            assertThatThrownBy(() -> residenceService.register("괴안동", member.getId()))
+                    .isInstanceOf(BadRequestException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.INVALID_REQUEST);
         }
     }
 }


### PR DESCRIPTION
## Issues
- #49 

## What is this PR? 👓
사용자의 거주지역 등록/삭제 기능에 대한 PR입니다.

## Key changes 🔑
- 사용자의 거주지역 등록
  - 이미 두 개 이상의 거주 지역을 설정했다면 예외를 발생시켰습니다.
- 사용자의 거주지역 삭제
  - 설정한 거주지역이 한 개뿐이라면 제거하지 못하도록 예외를 발생시켰습니다.
- jwtFilter 수정
  - 기존 지역 목록 조회의 API는 `/api/regions` 였습니다. 그런데 이 API는 비로그인상태에서 조회할 수 있어야 해서 filter를 타지 않도록 했습니다.
  - 거주지역 등록/삭제도 동일한 url을 가지고 있고 HttpMethod만 달라 GET 이면서 `/api/regions`인 요청만 filter를 타지 않도록 했습니다.

## To reviewers 👋
필터 로직을 확인해주세요~ 더 좋은 방법이 떠오르지 않아 GET && `/api/regions`로 했습니다!
혹시 더 좋은 방법이 떠오른다면 알려주세요!
