### PR TITLE
거주지역 등록 / 삭제 요청 및 로그인 성공 응답 API 수정

### DIFF
--- a/src/main/java/kr/codesquad/secondhand/application/auth/AuthService.java
+++ b/src/main/java/kr/codesquad/secondhand/application/auth/AuthService.java
@@ -1,5 +1,6 @@
 package kr.codesquad.secondhand.application.auth;
 
+import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import kr.codesquad.secondhand.application.image.ImageService;
 import kr.codesquad.secondhand.application.residence.ResidenceService;
@@ -12,6 +13,7 @@ import kr.codesquad.secondhand.exception.UnAuthorizedException;
 import kr.codesquad.secondhand.infrastructure.jwt.JwtExtractor;
 import kr.codesquad.secondhand.infrastructure.jwt.JwtProvider;
 import kr.codesquad.secondhand.presentation.dto.OauthTokenResponse;
+import kr.codesquad.secondhand.presentation.dto.member.AddressData;
 import kr.codesquad.secondhand.presentation.dto.member.LoginRequest;
 import kr.codesquad.secondhand.presentation.dto.member.LoginResponse;
 import kr.codesquad.secondhand.presentation.dto.member.SignUpRequest;
@@ -51,9 +53,11 @@ public class AuthService {
                 .memberId(memberId)
                 .token(refreshToken)
                 .build());
+
+        List<AddressData> addressData = residenceService.readResidenceOfMember(memberId);
         return new LoginResponse(
                 new AuthToken(jwtProvider.createAccessToken(memberId), refreshToken),
-                new UserResponse(userProfile.getEmail(), userProfile.getProfileUrl())
+                new UserResponse(userProfile.getEmail(), userProfile.getProfileUrl(), addressData)
         );
     }
 

--- a/src/main/java/kr/codesquad/secondhand/exception/NotFoundException.java
+++ b/src/main/java/kr/codesquad/secondhand/exception/NotFoundException.java
@@ -3,7 +3,7 @@ package kr.codesquad.secondhand.exception;
 public class NotFoundException extends SecondHandException {
 
     private static final String ITEM_NOT_FOUND_MESSAGE_FORMAT = "%s 번호의 아이템을 찾을 수 없습니다.";
-    private static final String REGION_NOT_FOUND_MESSAGE_FORMAT = "%s을 가진 지역을 찾을 수 없습니다.";
+    private static final String REGION_NOT_FOUND_MESSAGE_FORMAT = "아이디 %s를 가진 지역을 찾을 수 없습니다.";
 
     public NotFoundException(ErrorCode errorCode) {
         super(errorCode);
@@ -17,7 +17,7 @@ public class NotFoundException extends SecondHandException {
         return new NotFoundException(errorCode, String.format(ITEM_NOT_FOUND_MESSAGE_FORMAT, itemId));
     }
 
-    public static NotFoundException regionNotFound(ErrorCode errorCode, String addressName) {
-        return new NotFoundException(errorCode, String.format(REGION_NOT_FOUND_MESSAGE_FORMAT, addressName));
+    public static NotFoundException regionNotFound(ErrorCode errorCode, Long addressId) {
+        return new NotFoundException(errorCode, String.format(REGION_NOT_FOUND_MESSAGE_FORMAT, addressId));
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/presentation/ResidenceController.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/ResidenceController.java
@@ -34,14 +34,14 @@ public class ResidenceController {
     @PostMapping
     public ApiResponse<Void> registerResidence(@Valid @RequestBody ResidenceRequest request,
                                                @Auth Long memberId) {
-        residenceService.register(request.getAddress(), memberId);
+        residenceService.register(request.getAddressId(), memberId);
         return new ApiResponse<>(HttpStatus.OK.value());
     }
 
     @DeleteMapping
     public ApiResponse<Void> removeResidence(@Valid @RequestBody ResidenceRequest request,
                                              @Auth Long memberId) {
-        residenceService.remove(request.getAddress(), memberId);
+        residenceService.remove(request.getAddressId(), memberId);
         return new ApiResponse<>(HttpStatus.OK.value());
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/presentation/dto/member/AddressData.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/dto/member/AddressData.java
@@ -1,0 +1,15 @@
+package kr.codesquad.secondhand.presentation.dto.member;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AddressData {
+
+    private Long addressId;
+    private String fullAddressName;
+    private String addressName;
+}

--- a/src/main/java/kr/codesquad/secondhand/presentation/dto/member/UserResponse.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/dto/member/UserResponse.java
@@ -1,5 +1,6 @@
 package kr.codesquad.secondhand.presentation.dto.member;
 
+import java.util.List;
 import lombok.Getter;
 
 @Getter
@@ -7,9 +8,11 @@ public class UserResponse {
 
     private final String loginId;
     private final String profileUrl;
+    private final List<AddressData> addresses;
 
-    public UserResponse(String loginId, String profileUrl) {
+    public UserResponse(String loginId, String profileUrl, List<AddressData> addresses) {
         this.loginId = loginId;
         this.profileUrl = profileUrl;
+        this.addresses = addresses;
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/presentation/dto/residence/ResidenceRequest.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/dto/residence/ResidenceRequest.java
@@ -1,6 +1,6 @@
 package kr.codesquad.secondhand.presentation.dto.residence;
 
-import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -8,9 +8,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ResidenceRequest {
 
-    @NotBlank(message = "지역의 전체 이름은 들어와야합니다.")
-    private String fullAddress;
-
-    @NotBlank(message = "읍/면/동 이름은 들어와야 합니다.")
-    private String address;
+    @NotNull(message = "지역의 아이디 값은 반드시 들어와야합니다.")
+    private Long addressId;
 }

--- a/src/main/java/kr/codesquad/secondhand/repository/residence/ResidenceRepository.java
+++ b/src/main/java/kr/codesquad/secondhand/repository/residence/ResidenceRepository.java
@@ -1,9 +1,10 @@
 package kr.codesquad.secondhand.repository.residence;
 
 import kr.codesquad.secondhand.domain.residence.Residence;
+import kr.codesquad.secondhand.repository.residence.querydsl.ResidenceRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ResidenceRepository extends JpaRepository<Residence, Long> {
+public interface ResidenceRepository extends JpaRepository<Residence, Long>, ResidenceRepositoryCustom {
 
     int countByMemberId(Long memberId);
 

--- a/src/main/java/kr/codesquad/secondhand/repository/residence/querydsl/ResidenceRepositoryCustom.java
+++ b/src/main/java/kr/codesquad/secondhand/repository/residence/querydsl/ResidenceRepositoryCustom.java
@@ -1,0 +1,9 @@
+package kr.codesquad.secondhand.repository.residence.querydsl;
+
+import java.util.List;
+import kr.codesquad.secondhand.presentation.dto.member.AddressData;
+
+public interface ResidenceRepositoryCustom {
+
+    List<AddressData> findByMemberId(Long memberId);
+}

--- a/src/main/java/kr/codesquad/secondhand/repository/residence/querydsl/ResidenceRepositoryImpl.java
+++ b/src/main/java/kr/codesquad/secondhand/repository/residence/querydsl/ResidenceRepositoryImpl.java
@@ -1,0 +1,29 @@
+package kr.codesquad.secondhand.repository.residence.querydsl;
+
+import static kr.codesquad.secondhand.domain.residence.QRegion.region;
+import static kr.codesquad.secondhand.domain.residence.QResidence.residence;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import kr.codesquad.secondhand.presentation.dto.member.AddressData;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ResidenceRepositoryImpl implements ResidenceRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<AddressData> findByMemberId(Long memberId) {
+        return queryFactory
+                .select(Projections.fields(AddressData.class,
+                        region.id.as("addressId"),
+                        region.fullAddressName,
+                        region.addressName))
+                .from(residence)
+                .innerJoin(residence.region, region)
+                .where(residence.member.id.eq(memberId))
+                .fetch();
+    }
+}

--- a/src/test/java/kr/codesquad/secondhand/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/acceptance/AuthAcceptanceTest.java
@@ -15,8 +15,10 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import kr.codesquad.secondhand.domain.image.ImageFile;
+import kr.codesquad.secondhand.domain.member.Member;
 import kr.codesquad.secondhand.domain.member.UserProfile;
 import kr.codesquad.secondhand.domain.residence.Region;
+import kr.codesquad.secondhand.domain.residence.Residence;
 import kr.codesquad.secondhand.presentation.dto.OauthTokenResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -46,7 +48,16 @@ public class AuthAcceptanceTest extends AcceptanceTestSupport {
             // given
             mockingOAuth();
 
-            signup();
+            Member member = signup();
+            Region beoman = supportRepository.save(Region.builder()
+                    .fullAddressName("경기도 부천시 범안동")
+                    .addressName("범안동")
+                    .build());
+            supportRepository.save(Residence.builder()
+                    .region(beoman)
+                    .member(member)
+                    .addressName("범안동")
+                    .build());
 
             var request = RestAssured
                     .given().log().all()
@@ -64,7 +75,8 @@ public class AuthAcceptanceTest extends AcceptanceTestSupport {
                     () -> assertThat(response.jsonPath().getString("data.jwt.accessToken")).isNotNull(),
                     () -> assertThat(response.jsonPath().getString("data.jwt.refreshToken")).isNotNull(),
                     () -> assertThat(response.jsonPath().getString("data.user.loginId")).isNotNull(),
-                    () -> assertThat(response.jsonPath().getString("data.user.profileUrl")).isNotNull()
+                    () -> assertThat(response.jsonPath().getString("data.user.profileUrl")).isNotNull(),
+                    () -> assertThat(response.jsonPath().getString("data.user.addresses")).isNotNull()
             );
         }
 

--- a/src/test/java/kr/codesquad/secondhand/acceptance/ResidenceAcceptanceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/acceptance/ResidenceAcceptanceTest.java
@@ -19,7 +19,7 @@ import org.springframework.http.MediaType;
 
 public class ResidenceAcceptanceTest extends AcceptanceTestSupport {
 
-    private Region saveResidence(String fullAddress, String address) {
+    private Region saveRegion(String fullAddress, String address) {
         return supportRepository.save(Region.builder()
                 .fullAddressName(fullAddress)
                 .addressName(address)
@@ -101,13 +101,13 @@ public class ResidenceAcceptanceTest extends AcceptanceTestSupport {
         void givenAddressName_whenRegisterResidence_thenSuccess() {
             // given
             Member member = signup();
-            saveResidence("경기도 부천시 범안동", "범안동");
+            Region beomAn = saveRegion("경기도 부천시 범안동", "범안동");
 
             var request = RestAssured
                     .given().log().all()
                     .header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtProvider.createAccessToken(member.getId()))
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .body(Map.of("fullAddress", "경기도 부천시 범안동", "address", "범안동"));
+                    .body(Map.of("addressId", beomAn.getId()));
 
             // when
             var response = registerResidence(request);
@@ -121,8 +121,9 @@ public class ResidenceAcceptanceTest extends AcceptanceTestSupport {
         void givenAlreadyHasTwoResidenceMember_whenRegisterResidence_thenResponse400() {
             // given
             Member member = signup();
-            Region beoman = saveResidence("경기도 부천시 범안동", "범안동");
-            Region okgil = saveResidence("경기도 부천시 옥길동", "옥길동");
+            Region beoman = saveRegion("경기도 부천시 범안동", "범안동");
+            Region okgil = saveRegion("경기도 부천시 옥길동", "옥길동");
+            Region oryu = saveRegion("경기도 부천시 오류동", "오류동");
 
             supportRepository.save(Residence.from(member.getId(), beoman.getId(), "범안동"));
             supportRepository.save(Residence.from(member.getId(), okgil.getId(), "옥길동"));
@@ -131,7 +132,7 @@ public class ResidenceAcceptanceTest extends AcceptanceTestSupport {
                     .given().log().all()
                     .header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtProvider.createAccessToken(member.getId()))
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .body(Map.of("fullAddress", "경기도 부천시 오류동", "address", "오류동"));
+                    .body(Map.of("addressId", oryu.getId()));
 
             // when
             var response = registerResidence(request);
@@ -158,15 +159,15 @@ public class ResidenceAcceptanceTest extends AcceptanceTestSupport {
         void givenAddressName_whenRemoveResidence_thenSuccess() {
             // given
             Member member = signup();
-            Region beoman = saveResidence("경기도 부천시 범안동", "범안동");
-            Region okgil = saveResidence("경기도 부천시 옥길동", "옥길동");
+            Region beoman = saveRegion("경기도 부천시 범안동", "범안동");
+            Region okgil = saveRegion("경기도 부천시 옥길동", "옥길동");
             supportRepository.save(Residence.from(member.getId(), beoman.getId(), "범안동"));
             supportRepository.save(Residence.from(member.getId(), okgil.getId(), "옥길동"));
             var request = RestAssured
                     .given().log().all()
                     .header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtProvider.createAccessToken(member.getId()))
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .body(Map.of("fullAddress", "경기도 부천시 범안동", "address", "범안동"));
+                    .body(Map.of("addressId", okgil.getId()));
 
             // when
             var response = removeResidence(request);
@@ -180,14 +181,14 @@ public class ResidenceAcceptanceTest extends AcceptanceTestSupport {
         void givenMemberWhoHasOnlyOneResidence_whenRemoveResidence_thenResponse400() {
             // given
             Member member = signup();
-            Region beoman = saveResidence("경기도 부천시 범안동", "범안동");
+            Region beoman = saveRegion("경기도 부천시 범안동", "범안동");
             supportRepository.save(Residence.from(member.getId(), beoman.getId(), "범안동"));
 
             var request = RestAssured
                     .given().log().all()
                     .header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtProvider.createAccessToken(member.getId()))
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .body(Map.of("fullAddress", "경기도 부천시 범안동", "address", "범안동"));
+                    .body(Map.of("addressId", beoman.getId()));
 
             // when
             var response = removeResidence(request);

--- a/src/test/java/kr/codesquad/secondhand/application/residence/ResidenceServiceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/application/residence/ResidenceServiceTest.java
@@ -87,13 +87,13 @@ class ResidenceServiceTest extends ApplicationTestSupport {
         void givenAddressName_whenRegisterResidence_thenSuccess() {
             // given
             Member member = supportRepository.save(FixtureFactory.createMember());
-            supportRepository.save(Region.builder()
+            Region beomBak = supportRepository.save(Region.builder()
                     .fullAddressName("경기도 부천시 범박동")
                     .addressName("범박동")
                     .build());
 
             // when & then
-            assertThatCode(() -> residenceService.register("범박동", member.getId())).doesNotThrowAnyException();
+            assertThatCode(() -> residenceService.register(beomBak.getId(), member.getId())).doesNotThrowAnyException();
         }
 
         @DisplayName("사용자가 이미 두 개의 거주지역을 가지고 있으면 예외를 던진다.")
@@ -109,11 +109,15 @@ class ResidenceServiceTest extends ApplicationTestSupport {
                     .fullAddressName("경기도 부천시 옥길동")
                     .addressName("옥길동")
                     .build());
+            Region guaean = supportRepository.save(Region.builder()
+                    .fullAddressName("경기도 부천시 괴안동")
+                    .addressName("괴안동")
+                    .build());
             supportRepository.save(Residence.from(member.getId(), beombak.getId(), "범박동"));
             supportRepository.save(Residence.from(member.getId(), okgil.getId(), "옥길동"));
 
             // when & then
-            assertThatThrownBy(() -> residenceService.register("괴안동", member.getId()))
+            assertThatThrownBy(() -> residenceService.register(guaean.getId(), member.getId()))
                     .isInstanceOf(BadRequestException.class)
                     .extracting("errorCode").isEqualTo(ErrorCode.INVALID_REQUEST);
         }
@@ -140,7 +144,7 @@ class ResidenceServiceTest extends ApplicationTestSupport {
             supportRepository.save(Residence.from(member.getId(), okgil.getId(), "옥길동"));
 
             // when & then
-            assertThatCode(() -> residenceService.remove("범박동", member.getId()))
+            assertThatCode(() -> residenceService.remove(beombak.getId(), member.getId()))
                     .doesNotThrowAnyException();
         }
 
@@ -156,7 +160,7 @@ class ResidenceServiceTest extends ApplicationTestSupport {
             supportRepository.save(Residence.from(member.getId(), beombak.getId(), "범박동"));
 
             // when & then
-            assertThatThrownBy(() -> residenceService.remove("범박동", member.getId()))
+            assertThatThrownBy(() -> residenceService.remove(beombak.getId(), member.getId()))
                     .isInstanceOf(BadRequestException.class)
                     .extracting("errorCode").isEqualTo(ErrorCode.INVALID_REQUEST);
         }


### PR DESCRIPTION
## Issues
- #93

## What is this PR? 👓
거주지역 등록 / 삭제 요청 API, 로그인 성공 응답 API 수정에 대한 PR입니다.

## Key changes 🔑
- 거주지역 등록 / 삭제 요청 API 수정
  - 기존 `fullAddressName`, `addressName`을 request로 받던 것을 `addressId`를 받도록 수정
- 로그인 성공 응답 API 수정
  - 로그인한 회원의 주소 정보도 함께 응답하도록 수정

## To reviewers 👋
응답 형태가 올바른지 확인해주세용!
