### PR TITLE
채팅 목록 조회 테스트

### DIFF
--- a/src/main/java/kr/codesquad/secondhand/domain/chat/ChatRoom.java
+++ b/src/main/java/kr/codesquad/secondhand/domain/chat/ChatRoom.java
@@ -47,11 +47,11 @@ public class ChatRoom {
     @CreatedDate
     private LocalDateTime createdAt;
 
-    @JoinColumn(nullable = false, name = "from_id")
+    @JoinColumn(nullable = false, name = "sender_id")
     @ManyToOne(fetch = FetchType.LAZY)
     private Member sender;
 
-    @JoinColumn(nullable = false, name = "to_id")
+    @JoinColumn(nullable = false, name = "receiver_id")
     @ManyToOne(fetch = FetchType.LAZY)
     private Member receiver;
 

--- a/src/main/java/kr/codesquad/secondhand/presentation/dto/chat/ChatRoomResponse.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/dto/chat/ChatRoomResponse.java
@@ -1,20 +1,19 @@
 package kr.codesquad.secondhand.presentation.dto.chat;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class ChatRoomResponse {
 
     private Long chatRoomId;
     private String thumbnailUrl;
-    @JsonProperty(value = "chatPartnerName")
-    private String loginId;
-    @JsonProperty(value = "chatPartnerProfile")
-    private String profileUrl;
+    private String chatPartnerName;
+    private String chatPartnerProfile;
     private LocalDateTime lastSendTime;
     private String lastSendMessage;
     private Long newMessageCount;

--- a/src/main/java/kr/codesquad/secondhand/repository/chat/querydsl/ChatPaginationRepository.java
+++ b/src/main/java/kr/codesquad/secondhand/repository/chat/querydsl/ChatPaginationRepository.java
@@ -61,18 +61,18 @@ public class ChatPaginationRepository implements PaginationRepository {
                 .as("chatPartnerProfile");
     }
 
-    private JPQLQuery<LocalDateTime> findLastSendTimeById(Long chatRoomId) {
-        return JPAExpressions
-                .select(chatRoom.lastSendTime)
-                .from(chatRoom)
-                .where(chatRoom.id.eq(chatRoomId));
-    }
-
     private BooleanExpression beforeThanId(Long chatRoomId) {
         if (chatRoomId == null) {
             return null;
         }
         return chatRoom.lastSendTime.before(findLastSendTimeById(chatRoomId));
+    }
+
+    private JPQLQuery<LocalDateTime> findLastSendTimeById(Long chatRoomId) {
+        return JPAExpressions
+                .select(chatRoom.lastSendTime)
+                .from(chatRoom)
+                .where(chatRoom.id.eq(chatRoomId));
     }
 
     private BooleanExpression equalsMemberId(Long memberId) {

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -106,8 +106,8 @@ CREATE TABLE IF NOT EXISTS `second_hand`.`chat_room`
 (
     `id`             BIGINT        NOT NULL AUTO_INCREMENT,
     `created_at`     TIMESTAMP     NOT NULL,
-    `sender_id`        BIGINT        NOT NULL COMMENT '송신자 (최초 메시지 송신자)',
-    `receiver_id`          BIGINT        NOT NULL COMMENT '수신자 (최초 메시지 수신자)',
+    `sender_id`      BIGINT        NOT NULL COMMENT '송신자 (최초 메시지 송신자)',
+    `receiver_id`    BIGINT        NOT NULL COMMENT '수신자 (최초 메시지 수신자)',
     `item_id`        BIGINT        NOT NULL,
     `subject`        VARCHAR(1000) NOT NULL COMMENT '마지막으로 보낸 메시지',
     `status`         VARCHAR(45)   NOT NULL COMMENT '누가 마지막으로 메시지를 보냈는지 (from, to)',

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -106,8 +106,8 @@ CREATE TABLE IF NOT EXISTS `second_hand`.`chat_room`
 (
     `id`             BIGINT        NOT NULL AUTO_INCREMENT,
     `created_at`     TIMESTAMP     NOT NULL,
-    `from_id`        BIGINT        NOT NULL COMMENT '송신자 (최초 메시지 송신자)',
-    `to_id`          BIGINT        NOT NULL COMMENT '수신자 (최초 메시지 수신자)',
+    `sender_id`        BIGINT        NOT NULL COMMENT '송신자 (최초 메시지 송신자)',
+    `receiver_id`          BIGINT        NOT NULL COMMENT '수신자 (최초 메시지 수신자)',
     `item_id`        BIGINT        NOT NULL,
     `subject`        VARCHAR(1000) NOT NULL COMMENT '마지막으로 보낸 메시지',
     `status`         VARCHAR(45)   NOT NULL COMMENT '누가 마지막으로 메시지를 보냈는지 (from, to)',

--- a/src/test/java/kr/codesquad/secondhand/SupportRepository.java
+++ b/src/test/java/kr/codesquad/secondhand/SupportRepository.java
@@ -35,12 +35,12 @@ public class SupportRepository {
                 .getResultList();
     }
 
-    public List<?> save(List<?> entity) {
-        for (int i = 0; i < entity.size(); i++) {
-            em.persist(entity.get(i));
+    public <T> List<T> save(List<T> entities) {
+        for (int i = 0; i < entities.size(); i++) {
+            em.persist(entities.get(i));
         }
         em.flush();
         em.clear();
-        return entity;
+        return entities;
     }
 }

--- a/src/test/java/kr/codesquad/secondhand/SupportRepository.java
+++ b/src/test/java/kr/codesquad/secondhand/SupportRepository.java
@@ -34,4 +34,13 @@ public class SupportRepository {
         return em.createQuery(String.format("SELECT entity FROM %s entity", entityTypeName))
                 .getResultList();
     }
+
+    public List<?> save(List<?> entity) {
+        for (int i = 0; i < entity.size(); i++) {
+            em.persist(entity.get(i));
+        }
+        em.flush();
+        em.clear();
+        return entity;
+    }
 }

--- a/src/test/java/kr/codesquad/secondhand/application/chat/ChatRoomServiceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/application/chat/ChatRoomServiceTest.java
@@ -1,0 +1,82 @@
+package kr.codesquad.secondhand.application.chat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.List;
+import kr.codesquad.secondhand.SupportRepository;
+import kr.codesquad.secondhand.application.ApplicationTest;
+import kr.codesquad.secondhand.application.ApplicationTestSupport;
+import kr.codesquad.secondhand.domain.chat.ChatRoom;
+import kr.codesquad.secondhand.domain.item.Item;
+import kr.codesquad.secondhand.domain.member.Member;
+import kr.codesquad.secondhand.fixture.FixtureFactory;
+import kr.codesquad.secondhand.presentation.dto.CustomSlice;
+import kr.codesquad.secondhand.presentation.dto.chat.ChatRoomResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@ApplicationTest
+public class ChatRoomServiceTest extends ApplicationTestSupport {
+
+    @Autowired
+    private ChatRoomService chatRoomService;
+
+    @DisplayName("채팅 전체 목록을 조회할 떄")
+    @Nested
+    class Read {
+
+        @DisplayName("첫 페이지에서 최근 전송된 채팅 순으로 보여진다.")
+        @Test
+        void givenChatsData_whenFirstPage_thenSuccess() {
+            // given
+            Member member = signup();
+            List<Member> partners = getPartners();
+            Item item = supportRepository.save(FixtureFactory.createItem("item", "가전/잡화", member));
+            List<ChatRoom> chatRooms = (List<ChatRoom>) supportRepository.save(FixtureFactory.createChatRooms(member, partners, item));
+
+            // when
+            CustomSlice<ChatRoomResponse> response = chatRoomService.read(null, 10, 1L);
+
+            // then
+            assertAll(
+                    () -> assertThat(response.getPaging().isHasNext()).isTrue(),
+                    () -> assertThat(response.getPaging().getNextCursor()).isEqualTo(21),
+                    () -> assertThat(response.getContents().get(0).getChatPartnerName()).isEqualTo("30testId"),
+                    () -> assertThat(response.getContents().get(9).getChatPartnerName()).isEqualTo("21testId")
+            );
+
+        }
+
+        @DisplayName("마지막 페이지에서 최근 전송된 채팅 순으로 보여진다.")
+        @Test
+        void givenChatsDate_whenLastPage_thenSuccess() {
+            // given
+            Member member = signup();
+            List<Member> partners = getPartners();
+            Item item = supportRepository.save(FixtureFactory.createItem("item", "가전/잡화", member));
+            List<ChatRoom> chatRooms = FixtureFactory.createChatRooms(member, partners, item);
+
+            // when
+            CustomSlice<ChatRoomResponse> response = chatRoomService.read(21L, 10, 1L);
+
+
+            // then
+            assertAll(
+                    () -> assertThat(response.getPaging().isHasNext()).isFalse(),
+                    () -> assertThat(response.getPaging().getNextCursor()).isNull()
+            );
+
+        }
+
+        private Member signup() {
+            return supportRepository.save(FixtureFactory.createMember());
+        }
+
+        private List<Member> getPartners() {
+            return (List<Member>) supportRepository.save(FixtureFactory.createPartner());
+        }
+    }
+}

--- a/src/test/java/kr/codesquad/secondhand/application/chat/ChatRoomServiceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/application/chat/ChatRoomServiceTest.java
@@ -35,7 +35,7 @@ public class ChatRoomServiceTest extends ApplicationTestSupport {
             Member member = signup();
             List<Member> partners = getPartners();
             Item item = supportRepository.save(FixtureFactory.createItem("item", "가전/잡화", member));
-            List<ChatRoom> chatRooms = (List<ChatRoom>) supportRepository.save(FixtureFactory.createChatRooms(member, partners, item));
+            supportRepository.save(FixtureFactory.createChatRooms(member, partners, item));
 
             // when
             CustomSlice<ChatRoomResponse> response = chatRoomService.read(null, 10, 1L);
@@ -45,6 +45,7 @@ public class ChatRoomServiceTest extends ApplicationTestSupport {
                     () -> assertThat(response.getPaging().isHasNext()).isTrue(),
                     () -> assertThat(response.getPaging().getNextCursor()).isEqualTo(21),
                     () -> assertThat(response.getContents().get(0).getChatPartnerName()).isEqualTo("30testId"),
+                    () -> assertThat(response.getContents().get(0).getLastSendMessage()).isEqualTo("30번 채팅방"),
                     () -> assertThat(response.getContents().get(9).getChatPartnerName()).isEqualTo("21testId")
             );
 
@@ -57,16 +58,18 @@ public class ChatRoomServiceTest extends ApplicationTestSupport {
             Member member = signup();
             List<Member> partners = getPartners();
             Item item = supportRepository.save(FixtureFactory.createItem("item", "가전/잡화", member));
-            List<ChatRoom> chatRooms = FixtureFactory.createChatRooms(member, partners, item);
+            supportRepository.save(FixtureFactory.createChatRooms(member, partners, item));
 
             // when
-            CustomSlice<ChatRoomResponse> response = chatRoomService.read(21L, 10, 1L);
+            CustomSlice<ChatRoomResponse> response = chatRoomService.read(11L, 10, 1L);
 
 
             // then
             assertAll(
                     () -> assertThat(response.getPaging().isHasNext()).isFalse(),
-                    () -> assertThat(response.getPaging().getNextCursor()).isNull()
+                    () -> assertThat(response.getPaging().getNextCursor()).isNull(),
+                    () -> assertThat(response.getContents().get(0).getChatPartnerName()).isEqualTo("10testId"),
+                    () -> assertThat(response.getContents().get(9).getChatPartnerName()).isEqualTo("1testId")
             );
 
         }

--- a/src/test/java/kr/codesquad/secondhand/application/chat/ChatRoomServiceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/application/chat/ChatRoomServiceTest.java
@@ -4,10 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.util.List;
-import kr.codesquad.secondhand.SupportRepository;
 import kr.codesquad.secondhand.application.ApplicationTest;
 import kr.codesquad.secondhand.application.ApplicationTestSupport;
-import kr.codesquad.secondhand.domain.chat.ChatRoom;
 import kr.codesquad.secondhand.domain.item.Item;
 import kr.codesquad.secondhand.domain.member.Member;
 import kr.codesquad.secondhand.fixture.FixtureFactory;
@@ -48,7 +46,6 @@ public class ChatRoomServiceTest extends ApplicationTestSupport {
                     () -> assertThat(response.getContents().get(0).getLastSendMessage()).isEqualTo("30번 채팅방"),
                     () -> assertThat(response.getContents().get(9).getChatPartnerName()).isEqualTo("21testId")
             );
-
         }
 
         @DisplayName("마지막 페이지에서 최근 전송된 채팅 순으로 보여진다.")
@@ -63,7 +60,6 @@ public class ChatRoomServiceTest extends ApplicationTestSupport {
             // when
             CustomSlice<ChatRoomResponse> response = chatRoomService.read(11L, 10, 1L);
 
-
             // then
             assertAll(
                     () -> assertThat(response.getPaging().isHasNext()).isFalse(),
@@ -71,7 +67,6 @@ public class ChatRoomServiceTest extends ApplicationTestSupport {
                     () -> assertThat(response.getContents().get(0).getChatPartnerName()).isEqualTo("10testId"),
                     () -> assertThat(response.getContents().get(9).getChatPartnerName()).isEqualTo("1testId")
             );
-
         }
 
         private Member signup() {
@@ -79,7 +74,7 @@ public class ChatRoomServiceTest extends ApplicationTestSupport {
         }
 
         private List<Member> getPartners() {
-            return (List<Member>) supportRepository.save(FixtureFactory.createPartner());
+            return supportRepository.save(FixtureFactory.createPartner());
         }
     }
 }

--- a/src/test/java/kr/codesquad/secondhand/fixture/FixtureFactory.java
+++ b/src/test/java/kr/codesquad/secondhand/fixture/FixtureFactory.java
@@ -85,12 +85,12 @@ public class FixtureFactory {
 
     public static List<ChatRoom> createChatRooms(Member member, List<Member> partners, Item item) {
         List<ChatRoom> chatRooms = new ArrayList<>();
-        for (Member partner : partners) {
+        for (int i = 0; i < partners.size(); i++) {
             chatRooms.add(
                     ChatRoom.builder()
-                            .subject("대화내용")
+                            .subject(i+1 + "번 채팅방")
                             .status(WhoIsLast.FROM)
-                            .sender(partner)
+                            .sender(partners.get(i))
                             .receiver(member)
                             .item(item)
                             .build()

--- a/src/test/java/kr/codesquad/secondhand/fixture/FixtureFactory.java
+++ b/src/test/java/kr/codesquad/secondhand/fixture/FixtureFactory.java
@@ -85,13 +85,25 @@ public class FixtureFactory {
 
     public static List<ChatRoom> createChatRooms(Member member, List<Member> partners, Item item) {
         List<ChatRoom> chatRooms = new ArrayList<>();
-        for (int i = 0; i < partners.size(); i++) {
+        int tmp = partners.size() / 2;
+        for (int i = 0; i < tmp; i++) {
             chatRooms.add(
                     ChatRoom.builder()
-                            .subject(i+1 + "번 채팅방")
+                            .subject(i + 1 + "번 채팅방")
                             .status(WhoIsLast.FROM)
                             .sender(partners.get(i))
                             .receiver(member)
+                            .item(item)
+                            .build()
+            );
+        }
+        for (int i = tmp; i < partners.size(); i++) {
+            chatRooms.add(
+                    ChatRoom.builder()
+                            .subject(i + 1 + "번 채팅방")
+                            .status(WhoIsLast.FROM)
+                            .sender(member)
+                            .receiver(partners.get(i))
                             .item(item)
                             .build()
             );

--- a/src/test/java/kr/codesquad/secondhand/fixture/FixtureFactory.java
+++ b/src/test/java/kr/codesquad/secondhand/fixture/FixtureFactory.java
@@ -1,6 +1,9 @@
 package kr.codesquad.secondhand.fixture;
 
+import java.util.ArrayList;
 import java.util.List;
+import kr.codesquad.secondhand.domain.chat.ChatRoom;
+import kr.codesquad.secondhand.domain.chat.WhoIsLast;
 import kr.codesquad.secondhand.domain.item.Item;
 import kr.codesquad.secondhand.domain.item.ItemStatus;
 import kr.codesquad.secondhand.domain.member.Member;
@@ -64,5 +67,35 @@ public class FixtureFactory {
                 "가전/잡화",
                 List.of("url1", "url2")
         );
+    }
+
+    public static List<Member> createPartner() {
+        List<Member> members = new ArrayList<>();
+        for (int i = 1; i <= 30; i++) {
+            members.add(
+                    Member.builder()
+                            .email(i + "test@secondhand.com")
+                            .loginId(i + "testId")
+                            .profileUrl("image-url")
+                            .build()
+            );
+        }
+        return members;
+    }
+
+    public static List<ChatRoom> createChatRooms(Member member, List<Member> partners, Item item) {
+        List<ChatRoom> chatRooms = new ArrayList<>();
+        for (Member partner : partners) {
+            chatRooms.add(
+                    ChatRoom.builder()
+                            .subject("대화내용")
+                            .status(WhoIsLast.FROM)
+                            .sender(partner)
+                            .receiver(member)
+                            .item(item)
+                            .build()
+            );
+        }
+        return chatRooms;
     }
 }


### PR DESCRIPTION
## Issues
- #106 

## What is this PR? 👓
채팅 목록 조회 테스트에 대한 pr입니다.

## Key changes 🔑
- `ChatRoom` 필드 명 수정
- `ChatRoonResponse` 기본생성자 추가
- `ChatPaginationRepository` 서브쿼리 수정

## To reviewers 👋
채팅 목록을 `lastSendTime` 순으로 정렬해서 가져오는데, 이후에 채팅 전송 기능이 완성되면 변경된 `lastSendTime` 순으로 가져와지는지 테스트 추가하겠습니다!
