### PR TITLE
채팅방 생성 기능

### DIFF
--- a/src/main/java/kr/codesquad/secondhand/application/chat/ChatRoomService.java
+++ b/src/main/java/kr/codesquad/secondhand/application/chat/ChatRoomService.java
@@ -2,9 +2,15 @@ package kr.codesquad.secondhand.application.chat;
 
 import java.util.List;
 import kr.codesquad.secondhand.application.item.PagingUtils;
+import kr.codesquad.secondhand.domain.chat.ChatRoom;
+import kr.codesquad.secondhand.domain.item.Item;
+import kr.codesquad.secondhand.exception.ErrorCode;
+import kr.codesquad.secondhand.exception.NotFoundException;
 import kr.codesquad.secondhand.presentation.dto.CustomSlice;
 import kr.codesquad.secondhand.presentation.dto.chat.ChatRoomResponse;
+import kr.codesquad.secondhand.repository.chat.ChatRoomRepository;
 import kr.codesquad.secondhand.repository.chat.querydsl.ChatPaginationRepository;
+import kr.codesquad.secondhand.repository.item.ItemRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -15,7 +21,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class ChatRoomService {
 
+    private final ItemRepository itemRepository;
     private final ChatPaginationRepository chatPaginationRepository;
+    private final ChatRoomRepository chatRoomRepository;
 
     public CustomSlice<ChatRoomResponse> read(Long chatRoomId, int pageSize, Long memberId) {
         Slice<ChatRoomResponse> response =
@@ -25,5 +33,14 @@ public class ChatRoomService {
         Long nextCursor = PagingUtils.setNextCursorForChatRoom(content, response.hasNext());
 
         return new CustomSlice<>(content, nextCursor, response.hasNext());
+    }
+
+    @Transactional
+    public Long createChatRoom(Long itemId, Long senderId) {
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(() -> NotFoundException.itemNotFound(ErrorCode.NOT_FOUND, itemId));
+        ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.from(senderId, itemId, item.getMember().getId()));
+        item.increaseChatCount();
+        return chatRoom.getId();
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/application/member/MemberService.java
+++ b/src/main/java/kr/codesquad/secondhand/application/member/MemberService.java
@@ -23,16 +23,17 @@ public class MemberService {
     private String defaultProfileImage;
 
     @Transactional
-    public void modifyProfileImage(MultipartFile profileImage, Long memberId) {
+    public String modifyProfileImage(MultipartFile profileImage, Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND, "회원을 찾을 수 없습니다."));
 
         if (profileImage == null || profileImage.isEmpty()) {
             member.changeProfileImage(defaultProfileImage);
-            return;
+            return defaultProfileImage;
         }
 
         String updatedProfileImageUrl = imageService.uploadImage(profileImage);
         member.changeProfileImage(updatedProfileImageUrl);
+        return updatedProfileImageUrl;
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/domain/chat/ChatRoom.java
+++ b/src/main/java/kr/codesquad/secondhand/domain/chat/ChatRoom.java
@@ -4,8 +4,6 @@ import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -36,10 +34,6 @@ public class ChatRoom {
     @Column(nullable = false, length = 1000)
     private String subject;
 
-    @Column(nullable = false, length = 45)
-    @Enumerated(EnumType.STRING)
-    private WhoIsLast status;
-
     @Column(nullable = false)
     private LocalDateTime lastSendTime;
 
@@ -60,10 +54,9 @@ public class ChatRoom {
     private Item item;
 
     @Builder
-    private ChatRoom(Long id, String subject, WhoIsLast status, Member sender, Member receiver, Item item) {
+    private ChatRoom(Long id, String subject, Member sender, Member receiver, Item item) {
         this.id = id;
         this.subject = subject;
-        this.status = status;
         this.lastSendTime = LocalDateTime.now();
         this.sender = sender;
         this.receiver = receiver;
@@ -82,7 +75,6 @@ public class ChatRoom {
                 .receiver(Member.builder()
                         .id(sellerId)
                         .build())
-                .status(WhoIsLast.FROM)
                 .build();
     }
 

--- a/src/main/java/kr/codesquad/secondhand/domain/chat/WhoIsLast.java
+++ b/src/main/java/kr/codesquad/secondhand/domain/chat/WhoIsLast.java
@@ -1,6 +1,0 @@
-package kr.codesquad.secondhand.domain.chat;
-
-public enum WhoIsLast {
-
-    FROM, TO
-}

--- a/src/main/java/kr/codesquad/secondhand/domain/item/Item.java
+++ b/src/main/java/kr/codesquad/secondhand/domain/item/Item.java
@@ -125,4 +125,8 @@ public class Item extends AuditingFields {
     public void decreaseWishCount() {
         this.wishCount--;
     }
+
+    public void increaseChatCount() {
+        this.chatCount++;
+    }
 }

--- a/src/main/java/kr/codesquad/secondhand/presentation/ChatController.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/ChatController.java
@@ -1,5 +1,6 @@
 package kr.codesquad.secondhand.presentation;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import kr.codesquad.secondhand.application.chat.ChatLogService;
@@ -36,7 +37,7 @@ public class ChatController {
             @PathVariable Long chatRoomId,
             @RequestParam(required = false, defaultValue = "0") long messageIndex) {
         DeferredResult<ApiResponse<ChatLogResponse>> deferredResult =
-                new DeferredResult<>(1000L, new ApiResponse<>(HttpStatus.OK.value()));
+                new DeferredResult<>(10000L, new ApiResponse<>(HttpStatus.OK.value(), List.of()));
         chatRequests.put(deferredResult, messageIndex);
 
         deferredResult.onCompletion(() -> chatRequests.remove(deferredResult));

--- a/src/main/java/kr/codesquad/secondhand/presentation/ChatController.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/ChatController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.request.async.DeferredResult;
 
@@ -70,6 +71,7 @@ public class ChatController {
         return new ApiResponse<>(HttpStatus.OK.value());
     }
 
+    @ResponseStatus(value = HttpStatus.CREATED)
     @PostMapping("/items/{itemId}/chats")
     public ApiResponse<Map<String, Long>> createChatRoom(@PathVariable Long itemId, @Auth Long senderId) {
         Long chatRoomId = chatRoomService.createChatRoom(itemId, senderId);

--- a/src/main/java/kr/codesquad/secondhand/presentation/ChatController.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/ChatController.java
@@ -69,4 +69,10 @@ public class ChatController {
         }
         return new ApiResponse<>(HttpStatus.OK.value());
     }
+
+    @PostMapping("/items/{itemId}/chats")
+    public ApiResponse<Map<String, Long>> createChatRoom(@PathVariable Long itemId, @Auth Long senderId) {
+        Long chatRoomId = chatRoomService.createChatRoom(itemId, senderId);
+        return new ApiResponse<>(HttpStatus.CREATED.value(), Map.of("chatRoomId", chatRoomId));
+    }
 }

--- a/src/main/java/kr/codesquad/secondhand/presentation/MemberController.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/MemberController.java
@@ -1,5 +1,6 @@
 package kr.codesquad.secondhand.presentation;
 
+import java.util.Map;
 import kr.codesquad.secondhand.application.member.MemberService;
 import kr.codesquad.secondhand.presentation.dto.ApiResponse;
 import kr.codesquad.secondhand.presentation.support.Auth;
@@ -17,9 +18,9 @@ public class MemberController {
     private final MemberService memberService;
 
     @PutMapping("/api/members/{loginId}")
-    public ApiResponse<Void> modifyProfileImage(@RequestPart MultipartFile updateImageFile,
-                                                @Auth Long memberId) {
-        memberService.modifyProfileImage(updateImageFile, memberId);
-        return new ApiResponse<>(HttpStatus.OK.value());
+    public ApiResponse<Map<String, String>> modifyProfileImage(@RequestPart MultipartFile updateImageFile,
+                                                               @Auth Long memberId) {
+        String updatedProfileImageUrl = memberService.modifyProfileImage(updateImageFile, memberId);
+        return new ApiResponse<>(HttpStatus.OK.value(), Map.of("profileImageUrl", updatedProfileImageUrl));
     }
 }

--- a/src/main/resources/application-redis.yml
+++ b/src/main/resources/application-redis.yml
@@ -1,3 +1,3 @@
 redis:
-    host: localhost
-    port: 6379
+  host: 43.202.136.84
+  port: 6379

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -110,7 +110,6 @@ CREATE TABLE IF NOT EXISTS `second_hand`.`chat_room`
     `receiver_id`    BIGINT        NOT NULL COMMENT '수신자 (최초 메시지 수신자)',
     `item_id`        BIGINT        NOT NULL,
     `subject`        VARCHAR(1000) NOT NULL COMMENT '마지막으로 보낸 메시지',
-    `status`         VARCHAR(45)   NOT NULL COMMENT '누가 마지막으로 메시지를 보냈는지 (from, to)',
     `last_send_time` TIMESTAMP     NULL COMMENT '마지막 메시지 전송 시간',
     PRIMARY KEY (`id`)
 ) ENGINE = InnoDB;

--- a/src/test/java/kr/codesquad/secondhand/acceptance/ChatAcceptanceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/acceptance/ChatAcceptanceTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import io.restassured.RestAssured;
 import java.util.Map;
 import kr.codesquad.secondhand.domain.chat.ChatRoom;
-import kr.codesquad.secondhand.domain.chat.WhoIsLast;
 import kr.codesquad.secondhand.domain.item.Item;
 import kr.codesquad.secondhand.domain.member.Member;
 import kr.codesquad.secondhand.fixture.FixtureFactory;
@@ -29,7 +28,6 @@ public class ChatAcceptanceTest extends AcceptanceTestSupport {
         return supportRepository.save(ChatRoom.builder()
                 .item(item)
                 .subject("")
-                .status(WhoIsLast.FROM)
                 .receiver(receiver)
                 .sender(sender)
                 .build());

--- a/src/test/java/kr/codesquad/secondhand/acceptance/ChatAcceptanceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/acceptance/ChatAcceptanceTest.java
@@ -1,6 +1,7 @@
 package kr.codesquad.secondhand.acceptance;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import io.restassured.RestAssured;
 import java.util.Map;
@@ -59,6 +60,36 @@ public class ChatAcceptanceTest extends AcceptanceTestSupport {
 
             // then
             assertThat(response.statusCode()).isEqualTo(200);
+        }
+    }
+
+    @DisplayName("채팅방이 생성될 때")
+    @Nested
+    class CreateChatRoom {
+
+        @DisplayName("채팅방 생성에 성공한다.")
+        @Test
+        void given_whenCreateChatRoom_thenSuccess() {
+            // given
+            Member member = signup();
+            Item item = supportRepository.save(FixtureFactory.createItem("선풍기", "가전", member));
+
+            var request = RestAssured
+                    .given().log().all()
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtProvider.createAccessToken(member.getId()));
+
+            // when
+            var response = request
+                    .when()
+                    .post("/api/items/" + item.getId() + "/chats")
+                    .then().log().all()
+                    .extract();
+
+            // then
+            assertAll(
+                    () -> assertThat(response.statusCode()).isEqualTo(201),
+                    () -> assertThat(response.jsonPath().getString("data.chatRoomId"))
+            );
         }
     }
 }

--- a/src/test/java/kr/codesquad/secondhand/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/acceptance/MemberAcceptanceTest.java
@@ -1,10 +1,14 @@
 package kr.codesquad.secondhand.acceptance;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.given;
 
 import io.restassured.RestAssured;
-import java.io.File;
-import java.io.IOException;
+import io.restassured.builder.MultiPartSpecBuilder;
+import io.restassured.specification.MultiPartSpecification;
+import kr.codesquad.secondhand.domain.image.ImageFile;
 import kr.codesquad.secondhand.domain.member.Member;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,21 +17,27 @@ import org.springframework.http.MediaType;
 
 public class MemberAcceptanceTest extends AcceptanceTestSupport {
 
-    private File createFakeFile() throws IOException {
-        return File.createTempFile("test-image", ".png");
+    private MultiPartSpecification createFakeFile() {
+        return new MultiPartSpecBuilder("File content".getBytes())
+                .fileName("file.png")
+                .controlName("updateImageFile")
+                .mimeType(MediaType.IMAGE_PNG_VALUE)
+                .build();
     }
 
     @DisplayName("프로필 이미지를 변경할 때 변경할 프로필 사진이 주어지면 변경에 성공한다.")
     @Test
-    void givenProfileImage_whenModifyProfileImage_thenSuccess() throws IOException {
+    void givenProfileImage_whenModifyProfileImage_thenSuccess() {
         // given
+        given(s3Uploader.uploadImageFile(any(ImageFile.class))).willReturn("updatedProfileImage");
+
         Member member = signup();
 
         var request = RestAssured
                 .given().log().all()
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtProvider.createAccessToken(member.getId()))
                 .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
-                .multiPart("updateImageFile", createFakeFile(), MediaType.IMAGE_PNG_VALUE);
+                .multiPart(createFakeFile());
 
         // when
         var response = request
@@ -37,6 +47,9 @@ public class MemberAcceptanceTest extends AcceptanceTestSupport {
                 .extract();
 
         // then
-        assertThat(response.statusCode()).isEqualTo(200);
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(200),
+                () -> assertThat(response.jsonPath().getString("data.profileImageUrl")).isEqualTo("updatedProfileImage")
+        );
     }
 }

--- a/src/test/java/kr/codesquad/secondhand/application/chat/ChatLogServiceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/application/chat/ChatLogServiceTest.java
@@ -7,7 +7,6 @@ import java.util.List;
 import kr.codesquad.secondhand.application.ApplicationTestSupport;
 import kr.codesquad.secondhand.domain.chat.ChatLog;
 import kr.codesquad.secondhand.domain.chat.ChatRoom;
-import kr.codesquad.secondhand.domain.chat.WhoIsLast;
 import kr.codesquad.secondhand.domain.item.Item;
 import kr.codesquad.secondhand.domain.member.Member;
 import kr.codesquad.secondhand.fixture.FixtureFactory;
@@ -77,7 +76,6 @@ class ChatLogServiceTest extends ApplicationTestSupport {
         return supportRepository.save(ChatRoom.builder()
                 .item(item)
                 .subject("")
-                .status(WhoIsLast.FROM)
                 .receiver(receiver)
                 .sender(sender)
                 .build());

--- a/src/test/java/kr/codesquad/secondhand/application/chat/ChatRoomServiceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/application/chat/ChatRoomServiceTest.java
@@ -77,4 +77,28 @@ public class ChatRoomServiceTest extends ApplicationTestSupport {
             return supportRepository.save(FixtureFactory.createPartner());
         }
     }
+
+    @DisplayName("채팅방을 생성할 때")
+    @Nested
+    class Create {
+
+        @DisplayName("채팅방 생성에 성공한다.")
+        @Test
+        void given_whenCreateChatRoom_thenSuccess() {
+            // given
+            Member member = supportRepository.save(FixtureFactory.createMember());
+            Item item = supportRepository.save(FixtureFactory.createItem("선풍기", "가전", member));
+
+            // when
+            Long chatRoomId = chatRoomService.createChatRoom(item.getId(), member.getId());
+
+            // then
+            Item foundItem = supportRepository.findById(Item.class, item.getId()).get();
+
+            assertAll(
+                    () -> assertThat(chatRoomId).isNotNull(),
+                    () -> assertThat(foundItem.getChatCount()).isEqualTo(1)
+            );
+        }
+    }
 }

--- a/src/test/java/kr/codesquad/secondhand/application/member/MemberServiceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/application/member/MemberServiceTest.java
@@ -1,7 +1,6 @@
 package kr.codesquad.secondhand.application.member;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.given;
 
@@ -35,16 +34,18 @@ class MemberServiceTest extends ApplicationTestSupport {
         void givenUpdatedProfileImage_whenModifyProfileImage_thenSuccess() {
             // given
             Member member = supportRepository.save(FixtureFactory.createMember());
-            given(s3Uploader.uploadImageFile(any(ImageFile.class))).willReturn("profileUrl");
+            given(s3Uploader.uploadImageFile(any(ImageFile.class))).willReturn("updatedProfileUrl");
 
             MockMultipartFile profileImage = new MockMultipartFile("profile-image",
                     "profile-image.jpeg",
                     MediaType.IMAGE_JPEG_VALUE,
                     "profile-image-content".getBytes(StandardCharsets.UTF_8));
 
-            // when & then
-            assertThatCode(() -> memberService.modifyProfileImage(profileImage, member.getId()))
-                    .doesNotThrowAnyException();
+            // when
+            String updatedProfileUrl = memberService.modifyProfileImage(profileImage, member.getId());
+
+            // then
+            assertThat(updatedProfileUrl).isEqualTo("updatedProfileUrl");
         }
 
         @DisplayName("변경할 프로필 사진이 주어지지 않을 때 기본 이미지로 프로필 변경에 성공한다.")
@@ -54,10 +55,10 @@ class MemberServiceTest extends ApplicationTestSupport {
             Member member = supportRepository.save(FixtureFactory.createMember());
 
             // when
-            memberService.modifyProfileImage(null, member.getId());
+            String updatedProfileUrl = memberService.modifyProfileImage(null, member.getId());
+
             // then
-            Member savedMember = supportRepository.findById(Member.class, member.getId()).get();
-            assertThat(savedMember.getProfileUrl()).isEqualTo(defaultProfileUrl);
+            assertThat(updatedProfileUrl).isEqualTo(defaultProfileUrl);
         }
     }
 }

--- a/src/test/java/kr/codesquad/secondhand/fixture/FixtureFactory.java
+++ b/src/test/java/kr/codesquad/secondhand/fixture/FixtureFactory.java
@@ -3,7 +3,6 @@ package kr.codesquad.secondhand.fixture;
 import java.util.ArrayList;
 import java.util.List;
 import kr.codesquad.secondhand.domain.chat.ChatRoom;
-import kr.codesquad.secondhand.domain.chat.WhoIsLast;
 import kr.codesquad.secondhand.domain.item.Item;
 import kr.codesquad.secondhand.domain.item.ItemStatus;
 import kr.codesquad.secondhand.domain.member.Member;
@@ -102,7 +101,6 @@ public class FixtureFactory {
             chatRooms.add(
                     ChatRoom.builder()
                             .subject(i + 1 + "번 채팅방")
-                            .status(WhoIsLast.FROM)
                             .sender(partners.get(i))
                             .receiver(member)
                             .item(item)
@@ -113,7 +111,6 @@ public class FixtureFactory {
             chatRooms.add(
                     ChatRoom.builder()
                             .subject(i + 1 + "번 채팅방")
-                            .status(WhoIsLast.FROM)
                             .sender(member)
                             .receiver(partners.get(i))
                             .item(item)


### PR DESCRIPTION
## Issues
- #109 

## What is this PR? 👓
채팅방 생성 기능에 대한 PR입니다.

## Key changes 🔑
- 채팅방 생성
- 아이템의 채팅방 카운트 증가
- 테스트코드 작성

## To reviewers 👋
아이템의 채팅방 카운트는 별도의 이벤트로 뺄 이유가 없어 같은 로직에서 처리했습니다.
왜냐하면 같은 쓰기 트랜잭션이고 로직에서 `item`을 가지고 있어 같은 로직에서 처리했습니다.