### PR TITLE
화면에 보여질 메인 거주지역 선택

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -15,3 +15,4 @@
 include::auth.adoc[]
 include::category.adoc[]
 include::item.adoc[]
+include::residence.adoc[]

--- a/src/docs/asciidoc/residence.adoc
+++ b/src/docs/asciidoc/residence.adoc
@@ -1,0 +1,19 @@
+[[Category]]
+:toc: left
+:toclevels: 4
+== 지역
+
+=== 화면에 보여질 메인 거주 지역 선택
+
+.HTTP REQUEST
+include::{snippets}/residence/select/http-request.adoc[]
+.HTTP RESPONSE
+include::{snippets}/residence/select/http-response.adoc[]
+
+==== Request Fields
+
+include::{snippets}/residence/select/request-fields.adoc[]
+
+==== Response Fields
+
+include::{snippets}/residence/select/response-fields.adoc[]

--- a/src/main/java/kr/codesquad/secondhand/application/residence/ResidenceService.java
+++ b/src/main/java/kr/codesquad/secondhand/application/residence/ResidenceService.java
@@ -95,4 +95,10 @@ public class ResidenceService {
     public List<AddressData> readResidenceOfMember(Long memberId) {
         return residenceRepository.findByMemberId(memberId);
     }
+
+    @Transactional
+    public void selectResidence(Long regionId, Long memberId) {
+        List<Residence> residences = residenceRepository.findResidenceByMember_Id(memberId);
+        residences.forEach(residence -> residence.changeIsSelected(residence.getRegion().getId().equals(regionId)));
+    }
 }

--- a/src/main/java/kr/codesquad/secondhand/presentation/ResidenceController.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/ResidenceController.java
@@ -6,12 +6,14 @@ import kr.codesquad.secondhand.presentation.dto.ApiResponse;
 import kr.codesquad.secondhand.presentation.dto.CustomSlice;
 import kr.codesquad.secondhand.presentation.dto.residence.RegionResponse;
 import kr.codesquad.secondhand.presentation.dto.residence.ResidenceRequest;
+import kr.codesquad.secondhand.presentation.dto.residence.ResidenceSelectRequest;
 import kr.codesquad.secondhand.presentation.support.Auth;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -42,6 +44,13 @@ public class ResidenceController {
     public ApiResponse<Void> removeResidence(@Valid @RequestBody ResidenceRequest request,
                                              @Auth Long memberId) {
         residenceService.remove(request.getAddressId(), memberId);
+        return new ApiResponse<>(HttpStatus.OK.value());
+    }
+
+    @PutMapping
+    public ApiResponse<Void> selectResidence(@Valid @RequestBody ResidenceSelectRequest request,
+                                             @Auth Long memberId) {
+        residenceService.selectResidence(request.getSelectedAddressId(), memberId);
         return new ApiResponse<>(HttpStatus.OK.value());
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/presentation/dto/residence/ResidenceSelectRequest.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/dto/residence/ResidenceSelectRequest.java
@@ -1,0 +1,15 @@
+package kr.codesquad.secondhand.presentation.dto.residence;
+
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResidenceSelectRequest {
+
+    @NotNull(message = "선택된 거주지역은 요청에 반드시 포함되야 합니다.")
+    private Long selectedAddressId;
+}

--- a/src/main/java/kr/codesquad/secondhand/repository/residence/ResidenceRepository.java
+++ b/src/main/java/kr/codesquad/secondhand/repository/residence/ResidenceRepository.java
@@ -1,5 +1,6 @@
 package kr.codesquad.secondhand.repository.residence;
 
+import java.util.List;
 import kr.codesquad.secondhand.domain.residence.Residence;
 import kr.codesquad.secondhand.repository.residence.querydsl.ResidenceRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,4 +10,6 @@ public interface ResidenceRepository extends JpaRepository<Residence, Long>, Res
     int countByMemberId(Long memberId);
 
     void deleteByAddressName(String addressName);
+
+    List<Residence> findResidenceByMember_Id(Long memberId);
 }

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1498,7 +1498,7 @@ Content-Length: 78
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-09-20 23:22:31 +0900
+Last updated 2023-09-21 11:30:09 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/test/java/kr/codesquad/secondhand/acceptance/ResidenceAcceptanceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/acceptance/ResidenceAcceptanceTest.java
@@ -205,4 +205,41 @@ public class ResidenceAcceptanceTest extends AcceptanceTestSupport {
                     .extract();
         }
     }
+
+    @DisplayName("사용자가 메인 거주 지역을 선택할 때")
+    class Select {
+
+        @DisplayName("사용자가 선택한 지역 아이디가 주어지면 선택에 성공한다.")
+        @Test
+        void givenSelectedAddressId_whenSelectResidence_thenSuccess() {
+            // given
+            Member member = signup();
+            Region beoman = supportRepository.save(Region.builder().addressName("범안동")
+                    .fullAddressName("경기도 부천시 범안동")
+                    .build());
+            Region okgil = supportRepository.save(Region.builder().addressName("옥길동")
+                    .fullAddressName("경기도 부천시 옥길동")
+                    .build());
+
+            Residence mainResidence = supportRepository.save(
+                    Residence.from(member.getId(), beoman.getId(), "범안동", true));
+            Residence residence = supportRepository.save(Residence.from(member.getId(), okgil.getId(), "범안동", false));
+
+            var request = RestAssured
+                    .given().log().all()
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtProvider.createAccessToken(member.getId()))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(Map.of("selectedAddressId", okgil.getId()));
+
+            // when
+            var response = request
+                    .when()
+                    .put("/api/regions")
+                    .then().log().all()
+                    .extract();
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(200);
+        }
+    }
 }

--- a/src/test/java/kr/codesquad/secondhand/application/residence/ResidenceServiceTest.java
+++ b/src/test/java/kr/codesquad/secondhand/application/residence/ResidenceServiceTest.java
@@ -165,4 +165,38 @@ class ResidenceServiceTest extends ApplicationTestSupport {
                     .extracting("errorCode").isEqualTo(ErrorCode.INVALID_REQUEST);
         }
     }
+
+    @DisplayName("사용자가 메인 거주 지역을 선택할 때")
+    @Nested
+    class Select {
+
+        @DisplayName("지역 아이디가 주어지면 선택에 성공한다.")
+        @Test
+        void givenSelectedAddressId_whenSelectResidence_thenSuccess() {
+            // given
+            Member member = supportRepository.save(FixtureFactory.createMember());
+            Region beoman = supportRepository.save(Region.builder().addressName("범안동")
+                    .fullAddressName("경기도 부천시 범안동")
+                    .build());
+            Region okgil = supportRepository.save(Region.builder().addressName("옥길동")
+                    .fullAddressName("경기도 부천시 옥길동")
+                    .build());
+
+            Residence mainResidence = supportRepository.save(
+                    Residence.from(member.getId(), beoman.getId(), "범안동", true));
+            Residence residence = supportRepository.save(Residence.from(member.getId(), okgil.getId(), "범안동", false));
+
+            // when
+            residenceService.selectResidence(okgil.getId(), member.getId());
+
+            // then
+            Residence notSelectedResidence = supportRepository.findById(Residence.class, mainResidence.getId()).get();
+            Residence selectedResidence = supportRepository.findById(Residence.class, residence.getId()).get();
+
+            assertAll(
+                    () -> assertThat(notSelectedResidence.isSelected()).isFalse(),
+                    () -> assertThat(selectedResidence.isSelected()).isTrue()
+            );
+        }
+    }
 }

--- a/src/test/java/kr/codesquad/secondhand/documentation/residence/ResidenceDocumentationTest.java
+++ b/src/test/java/kr/codesquad/secondhand/documentation/residence/ResidenceDocumentationTest.java
@@ -1,0 +1,71 @@
+package kr.codesquad.secondhand.documentation.residence;
+
+import static kr.codesquad.secondhand.documentation.support.ConstraintsHelper.withPath;
+import static org.mockito.BDDMockito.anyLong;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import kr.codesquad.secondhand.application.residence.ResidenceService;
+import kr.codesquad.secondhand.documentation.DocumentationTestSupport;
+import kr.codesquad.secondhand.presentation.dto.residence.ResidenceSelectRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+public class ResidenceDocumentationTest extends DocumentationTestSupport {
+
+    @Autowired
+    private ResidenceService residenceService;
+
+    @DisplayName("메인 거주 지역 선택")
+    @Test
+    void selectResidence() throws Exception {
+        // given
+        ResidenceSelectRequest request = new ResidenceSelectRequest(1L);
+
+        willDoNothing().given(residenceService).selectResidence(anyLong(), anyLong());
+
+        // when
+        var response = mockMvc.perform(put("/api/regions")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtProvider.createAccessToken(1L))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        var resultActions = response.andExpect(status().isOk())
+                .andExpect(jsonPath("statusCode").value(200))
+                .andExpect(jsonPath("message").value("성공했습니다."));
+
+        // docs
+        resultActions.andDo(document("residence/select",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestHeaders(
+                        headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰을 담는 인증 헤더")
+                ),
+                requestFields(
+                        withPath("selectedAddressId", ResidenceSelectRequest.class).description("사용자가 선택한 지역 ID")
+                ),
+                responseFields(
+                        fieldWithPath("statusCode").type(NUMBER).description("응답코드"),
+                        fieldWithPath("message").type(STRING).description("응답 메시지"),
+                        fieldWithPath("data").ignored()
+                )
+        ));
+    }
+}


### PR DESCRIPTION
## Issues
- #118 

## What is this PR? 👓
화면에 보여질 메인 거주지역 선택 기능에 대한 PR입니다.

## Key changes 🔑
- 사용자가 선택한 지역(region)아이디가 주어지면 해당 지역 아이디의 거주지역을 메인 거주지역으로 변경
- 그 외의 거주지역의 `is_selected` 컬럼은 false로 변경
- 테스트코드 작성

## To reviewers 👋
거주지역 선택 로직(service)이 올바른지 확인해주세용!