### PR TITLE
채팅방 목록 조회 로직 수정

### DIFF
--- a/src/main/java/kr/codesquad/secondhand/application/chat/ChatLogService.java
+++ b/src/main/java/kr/codesquad/secondhand/application/chat/ChatLogService.java
@@ -1,8 +1,5 @@
 package kr.codesquad.secondhand.application.chat;
 
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.LongStream;
 import kr.codesquad.secondhand.application.chat.event.ChatReadEvent;
 import kr.codesquad.secondhand.domain.chat.ChatLog;
 import kr.codesquad.secondhand.domain.chat.ChatRoom;
@@ -20,6 +17,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -60,8 +61,9 @@ public class ChatLogService {
 
         ChatLog chatLog = ChatLog.of(chatRoom, message, senderId);
         chatLogRepository.save(chatLog);
-
+        
         chatRoom.setLastSendMessage(message);
+        chatRoom.changeLastSendTime();
         // TODO: 알람 보내기
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/application/chat/ChatLogService.java
+++ b/src/main/java/kr/codesquad/secondhand/application/chat/ChatLogService.java
@@ -60,6 +60,8 @@ public class ChatLogService {
 
         ChatLog chatLog = ChatLog.of(chatRoom, message, senderId);
         chatLogRepository.save(chatLog);
+
+        chatRoom.setLastSendMessage(message);
         // TODO: 알람 보내기
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/application/chat/ChatRoomService.java
+++ b/src/main/java/kr/codesquad/secondhand/application/chat/ChatRoomService.java
@@ -34,8 +34,7 @@ public class ChatRoomService {
     private final ChatLogRepository chatLogRepository;
 
     public CustomSlice<ChatRoomResponse> read(Long memberId, Pageable pageable) {
-        Slice<ChatRoomResponse> response =
-                chatPaginationRepository.findByMemberId(memberId, pageable);
+        Slice<ChatRoomResponse> response = chatPaginationRepository.findByMemberId(memberId, pageable);
 
         List<ChatRoomResponse> contents = response.getContent();
 
@@ -65,10 +64,9 @@ public class ChatRoomService {
         return chatRoom.getId();
     }
 
-    public boolean existsMessageAfterMessageId(Long messageId) {
-        if (messageId == null) {
-            return true;
-        }
-        return chatLogRepository.existsByIdGreaterThan(messageId);
+    public Long getReceiverId(Long chatRoomId) {
+        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND));
+        return chatRoom.getSeller().getId();
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/application/chat/ChatRoomService.java
+++ b/src/main/java/kr/codesquad/secondhand/application/chat/ChatRoomService.java
@@ -1,15 +1,11 @@
 package kr.codesquad.secondhand.application.chat;
 
-import java.util.List;
-import java.util.Map;
-import kr.codesquad.secondhand.domain.chat.ChatLog;
 import kr.codesquad.secondhand.domain.chat.ChatRoom;
 import kr.codesquad.secondhand.domain.item.Item;
 import kr.codesquad.secondhand.exception.ErrorCode;
 import kr.codesquad.secondhand.exception.NotFoundException;
 import kr.codesquad.secondhand.presentation.dto.CustomSlice;
 import kr.codesquad.secondhand.presentation.dto.chat.ChatRoomResponse;
-import kr.codesquad.secondhand.repository.chat.ChatLogRepository;
 import kr.codesquad.secondhand.repository.chat.ChatRoomRepository;
 import kr.codesquad.secondhand.repository.chat.querydsl.ChatCountRepository;
 import kr.codesquad.secondhand.repository.chat.querydsl.ChatPaginationRepository;
@@ -19,6 +15,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -31,7 +30,6 @@ public class ChatRoomService {
     private final ChatPaginationRepository chatPaginationRepository;
     private final ChatRoomRepository chatRoomRepository;
     private final ChatCountRepository chatCountRepository;
-    private final ChatLogRepository chatLogRepository;
 
     public CustomSlice<ChatRoomResponse> read(Long memberId, Pageable pageable) {
         Slice<ChatRoomResponse> response = chatPaginationRepository.findByMemberId(memberId, pageable);
@@ -49,10 +47,7 @@ public class ChatRoomService {
         boolean hasNext = response.hasNext();
         Long nextCursor = hasNext ? Long.valueOf(pageable.getPageNumber() + 1) : null;
 
-        ChatLog lastChatLog = chatLogRepository.findFirstByOrderByIdDesc().orElse(null);
-        Long lastChatLogId = lastChatLog != null ? lastChatLog.getId() : null;
-
-        return new CustomSlice<>(contents, nextCursor, response.hasNext(), lastChatLogId);
+        return new CustomSlice<>(contents, nextCursor, response.hasNext());
     }
 
     @Transactional

--- a/src/main/java/kr/codesquad/secondhand/domain/chat/ChatRoom.java
+++ b/src/main/java/kr/codesquad/secondhand/domain/chat/ChatRoom.java
@@ -1,16 +1,5 @@
 package kr.codesquad.secondhand.domain.chat;
 
-import java.time.LocalDateTime;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EntityListeners;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
 import kr.codesquad.secondhand.domain.item.Item;
 import kr.codesquad.secondhand.domain.member.Member;
 import lombok.AccessLevel;
@@ -19,6 +8,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -80,5 +72,9 @@ public class ChatRoom {
 
     public void setLastSendMessage(String message) {
         this.subject = message;
+    }
+
+    public void changeLastSendTime() {
+        this.lastSendTime = LocalDateTime.now();
     }
 }

--- a/src/main/java/kr/codesquad/secondhand/domain/chat/ChatRoom.java
+++ b/src/main/java/kr/codesquad/secondhand/domain/chat/ChatRoom.java
@@ -77,4 +77,8 @@ public class ChatRoom {
                         .build())
                 .build();
     }
+
+    public void setLastSendMessage(String message) {
+        this.subject = message;
+    }
 }

--- a/src/main/java/kr/codesquad/secondhand/presentation/ChatController.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/ChatController.java
@@ -1,8 +1,5 @@
 package kr.codesquad.secondhand.presentation;
 
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import kr.codesquad.secondhand.application.chat.ChatLogService;
 import kr.codesquad.secondhand.application.chat.ChatRoomService;
 import kr.codesquad.secondhand.presentation.dto.ApiResponse;
@@ -15,15 +12,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.request.async.DeferredResult;
+
+import javax.validation.Valid;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @RequiredArgsConstructor
 @RequestMapping("/api")
@@ -58,32 +53,38 @@ public class ChatController {
     @GetMapping("/chats")
     public DeferredResult<ApiResponse<CustomSlice<ChatRoomResponse>>> readList(
             @PageableDefault Pageable pageable,
-            @RequestParam(required = false) Long messageId,
             @Auth Long memberId) {
+        CustomSlice<ChatRoomResponse> chatRooms = chatRoomService.read(memberId, pageable);
+
         DeferredResult<ApiResponse<CustomSlice<ChatRoomResponse>>> deferredResult =
-                new DeferredResult<>(10000L, new ApiResponse<>(HttpStatus.OK.value(), List.of()));
-        chatRoomRequests.put(deferredResult, messageId);
+                new DeferredResult<>(10000L, new ApiResponse<>(HttpStatus.OK.value(), chatRooms));
+        chatRoomRequests.put(deferredResult, memberId);
 
         deferredResult.onCompletion(() -> chatRoomRequests.remove(deferredResult));
-
-        if (chatRoomService.existsMessageAfterMessageId(messageId)) {
-            CustomSlice<ChatRoomResponse> chatRooms = chatRoomService.read(memberId, pageable);
-            deferredResult.setResult(new ApiResponse<>(HttpStatus.OK.value(), chatRooms));
-        }
 
         return deferredResult;
     }
 
     @PostMapping("/chats/{chatRoomId}")
-    public ApiResponse<Void> sendMessage(@RequestBody ChatRequest request,
+    public ApiResponse<Void> sendMessage(@Valid @RequestBody ChatRequest request,
                                          @PathVariable Long chatRoomId,
                                          @Auth Long senderId) {
+        Long receiverId = chatRoomService.getReceiverId(chatRoomId);
         chatLogService.sendMessage(request.getMessage(), chatRoomId, senderId);
 
         for (var entry : chatRequests.entrySet()) {
             ChatLogResponse messages = chatLogService.getMessages(chatRoomId, entry.getValue(), senderId);
             entry.getKey().setResult(new ApiResponse<>(HttpStatus.OK.value(), messages));
         }
+
+        for (var entry : chatRoomRequests.entrySet()) {
+            if (!entry.getValue().equals(receiverId)) {
+                continue;
+            }
+            CustomSlice<ChatRoomResponse> chatRooms = chatRoomService.read(senderId, Pageable.ofSize(10));
+            entry.getKey().setResult(new ApiResponse<>(HttpStatus.OK.value(), chatRooms));
+        }
+
         return new ApiResponse<>(HttpStatus.OK.value());
     }
 

--- a/src/main/java/kr/codesquad/secondhand/presentation/dto/ApiResponse.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/dto/ApiResponse.java
@@ -1,8 +1,10 @@
 package kr.codesquad.secondhand.presentation.dto;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class ApiResponse<T> {
 
     private int statusCode;

--- a/src/main/java/kr/codesquad/secondhand/presentation/dto/CustomSlice.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/dto/CustomSlice.java
@@ -1,27 +1,19 @@
 package kr.codesquad.secondhand.presentation.dto;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+
+import java.util.List;
 
 @Getter
 public class CustomSlice<T> {
 
     private final List<T> contents;
     private final Paging paging;
-    @JsonInclude(Include.NON_NULL)
-    private Long lastMessageId;
 
     public CustomSlice(List<T> contents, Long nextCursor, boolean hasNext) {
         this.contents = contents;
         this.paging = new Paging(nextCursor, hasNext);
-    }
-
-    public CustomSlice(List<T> contents, Long nextCursor, boolean hasNext, Long lastMessageId) {
-        this(contents, nextCursor, hasNext);
-        this.lastMessageId = lastMessageId;
     }
 
     @AllArgsConstructor

--- a/src/main/java/kr/codesquad/secondhand/presentation/dto/chat/ChatRequest.java
+++ b/src/main/java/kr/codesquad/secondhand/presentation/dto/chat/ChatRequest.java
@@ -3,9 +3,12 @@ package kr.codesquad.secondhand.presentation.dto.chat;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotNull;
+
 @Getter
 @NoArgsConstructor
 public class ChatRequest {
 
+    @NotNull(message = "채팅 메시지는 null 일 수 없습니다.")
     private String message;
 }

--- a/src/test/java/kr/codesquad/secondhand/documentation/presentation/ChatControllerTest.java
+++ b/src/test/java/kr/codesquad/secondhand/documentation/presentation/ChatControllerTest.java
@@ -1,0 +1,96 @@
+package kr.codesquad.secondhand.documentation.presentation;
+
+import kr.codesquad.secondhand.application.chat.ChatLogService;
+import kr.codesquad.secondhand.application.chat.ChatRoomService;
+import kr.codesquad.secondhand.documentation.DocumentationTestSupport;
+import kr.codesquad.secondhand.presentation.dto.ApiResponse;
+import kr.codesquad.secondhand.presentation.dto.CustomSlice;
+import kr.codesquad.secondhand.presentation.dto.chat.ChatRoomResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class ChatControllerTest extends DocumentationTestSupport {
+
+    @Autowired
+    private ChatLogService chatLogService;
+
+    @Autowired
+    private ChatRoomService chatRoomService;
+
+    @DisplayName("채팅방 목록 조회")
+    @Test
+    void readAllChatRooms() throws Exception {
+        // given
+        Long chatRoomId = 1L;
+        Long receiverId = 1L;
+        Long senderId = 2L;
+
+        var pagedChatRoomResponse = createPagedChatRoomResponse(chatRoomId);
+
+        willDoNothing().given(chatLogService).sendMessage(anyString(), anyLong(), anyLong());
+        given(chatRoomService.getReceiverId(anyLong())).willReturn(receiverId);
+        given(chatRoomService.read(anyLong(), any(Pageable.class))).willReturn(pagedChatRoomResponse);
+
+        var asyncListener = mockMvc.perform(MockMvcRequestBuilders.request(HttpMethod.GET, "/api/chats")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtProvider.createAccessToken(receiverId)))
+                .andExpect(request().asyncStarted())
+                .andReturn();
+
+        // when
+        sendMessage(senderId, chatRoomId);
+
+        var resultActions = mockMvc.perform(asyncDispatch(asyncListener));
+
+        // then
+        String response = resultActions
+                .andReturn()
+                .getResponse()
+                .getContentAsString(StandardCharsets.UTF_8);
+
+        ApiResponse<CustomSlice<ChatRoomResponse>> apiResponse = objectMapper.readValue(response, ApiResponse.class);
+
+        assertThat(apiResponse.getStatusCode()).isEqualTo(200);
+    }
+
+    private CustomSlice<ChatRoomResponse> createPagedChatRoomResponse(Long chatRoomId) {
+        var chatRoomResponse = new ChatRoomResponse(
+                chatRoomId,
+                "item-thumbnail",
+                "sender",
+                "sender-profile",
+                LocalDateTime.now(),
+                "",
+                1L);
+        return new CustomSlice<>(List.of(chatRoomResponse), null, false);
+    }
+
+    private void sendMessage(Long senderId, Long chatRoomId) throws Exception {
+        given(authenticationContext.getMemberId()).willReturn(Optional.of(senderId));
+
+        mockMvc.perform(post("/api/chats/{chatRoomId}", chatRoomId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtProvider.createAccessToken(senderId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"message\": \"hello\"}"))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+}


### PR DESCRIPTION
## Issues
- #134 

## What is this PR? 👓
채팅방 목록 조회 로직 수정에 대한 PR입니다.

## Key changes 🔑
- `messageId` 제거
- 채팅 전송시에 새로운 채팅이 생겨 해당 채팅방이 최상단으로 올라가기 때문에 `DeferredResult setResult` 로직을 `sendMessage`로 이동

## To reviewers 👋
